### PR TITLE
fix: auto-reconnect on backend server crash

### DIFF
--- a/internal/hierarchy/hierarchy.go
+++ b/internal/hierarchy/hierarchy.go
@@ -399,6 +399,7 @@ func (h *Hierarchy) ResolveToolPath(toolPath string) (*ToolDefinition, string, e
 }
 
 // HandleExecuteTool handles the execute_tool meta-tool
+// Implements automatic retry with reconnection on transport errors
 func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegistry, toolPath string, arguments map[string]interface{}) (*mcp.CallToolResult, error) {
 	// Resolve the tool path to get tool definition and server name
 	toolDef, serverName, err := h.ResolveToolPath(toolPath)
@@ -410,35 +411,60 @@ func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegis
 		return nil, fmt.Errorf("no MCP server configured for tool: %s", toolPath)
 	}
 
-	// Get or load the MCP client for this server
-	client, err := registry.GetOrLoadServer(ctx, serverName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get MCP client: %w", err)
-	}
-
 	// Use the mapped tool name
 	actualToolName := toolDef.MapsTo
 	if actualToolName == "" {
 		actualToolName = strings.Split(toolPath, ".")[len(strings.Split(toolPath, "."))-1]
 	}
 
-	log.Printf("Executing tool: hierarchy_path=%s, server=%s, tool=%s", toolPath, serverName, actualToolName)
+	// Try up to 2 times: first attempt, then retry with fresh connection if transport error
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			log.Printf("Retrying tool execution after transport error (attempt %d): %s", attempt+1, toolPath)
+		}
 
-	// Create a context with 15-second timeout for tool execution
-	toolCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
+		// Get or load the MCP client for this server
+		mcpClient, err := registry.GetOrLoadServer(ctx, serverName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get MCP client: %w", err)
+		}
 
-	// Call the tool on the actual MCP server
-	callRequest := mcp.CallToolRequest{}
-	callRequest.Params.Name = actualToolName
-	callRequest.Params.Arguments = arguments
+		log.Printf("Executing tool: hierarchy_path=%s, server=%s, tool=%s (attempt %d)", toolPath, serverName, actualToolName, attempt+1)
 
-	result, err := client.GetClient().CallTool(toolCtx, callRequest)
-	if err != nil {
+		// Create a context with 30-second timeout for tool execution
+		// Increased from 15s to allow for slower tools and retries
+		toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+		// Call the tool on the actual MCP server
+		callRequest := mcp.CallToolRequest{}
+		callRequest.Params.Name = actualToolName
+		callRequest.Params.Arguments = arguments
+
+		result, err := mcpClient.GetClient().CallTool(toolCtx, callRequest)
+		cancel() // Clean up context
+
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		// Check if this is a transport error (broken pipe, connection reset, etc.)
+		if isTransportError(err) {
+			log.Printf("Transport error detected for server %s: %v", serverName, err)
+			// Remove the stale client from cache so next attempt gets a fresh connection
+			registry.RemoveClient(serverName)
+			// Continue to retry
+			continue
+		}
+
+		// Non-transport error, don't retry
 		return nil, fmt.Errorf("failed to call tool %s: %w", actualToolName, err)
 	}
 
-	return result, nil
+	// All retries exhausted
+	return nil, fmt.Errorf("failed to call tool %s after retry: %w", actualToolName, lastErr)
 }
 
 // ServerRegistry manages MCP client connections
@@ -520,6 +546,19 @@ func (r *ServerRegistry) GetOrLoadServer(ctx context.Context, serverName string)
 	return mcpClient, nil
 }
 
+// RemoveClient removes a client from the registry, allowing it to be reconnected
+// This is used when a transport error is detected to force a fresh connection
+func (r *ServerRegistry) RemoveClient(serverName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if client, exists := r.clients[serverName]; exists {
+		log.Printf("Removing stale MCP client from cache: %s", serverName)
+		_ = client.Close()
+		delete(r.clients, serverName)
+	}
+}
+
 // Close closes all clients in the registry
 func (r *ServerRegistry) Close() {
 	r.mu.Lock()
@@ -529,4 +568,34 @@ func (r *ServerRegistry) Close() {
 		log.Printf("Closing MCP client: %s", name)
 		_ = client.Close()
 	}
+}
+
+// isTransportError checks if an error is a transport-level error indicating
+// the connection is dead (broken pipe, connection reset, EOF, etc.)
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	// Common transport error patterns
+	transportErrors := []string{
+		"broken pipe",
+		"connection reset",
+		"connection refused",
+		"EOF",
+		"use of closed network connection",
+		"context deadline exceeded",
+		"i/o timeout",
+		"no such host",
+		"connection timed out",
+		"transport endpoint is not connected",
+		"write: broken pipe",
+		"read: connection reset",
+	}
+	for _, pattern := range transportErrors {
+		if strings.Contains(strings.ToLower(errStr), strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hierarchy/transport_error_test.go
+++ b/internal/hierarchy/transport_error_test.go
@@ -1,0 +1,125 @@
+package hierarchy
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsTransportError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		// Should detect as transport errors
+		{
+			name:     "broken pipe",
+			err:      errors.New("write: broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "EOF",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			name:     "closed network connection",
+			err:      errors.New("use of closed network connection"),
+			expected: true,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      errors.New("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "i/o timeout",
+			err:      errors.New("i/o timeout"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection timed out",
+			err:      errors.New("dial tcp: connection timed out"),
+			expected: true,
+		},
+		{
+			name:     "transport endpoint not connected",
+			err:      errors.New("transport endpoint is not connected"),
+			expected: true,
+		},
+		{
+			name:     "no such host",
+			err:      errors.New("dial tcp: lookup foo: no such host"),
+			expected: true,
+		},
+		// Case insensitivity
+		{
+			name:     "BROKEN PIPE uppercase",
+			err:      errors.New("BROKEN PIPE"),
+			expected: true,
+		},
+		// Should NOT detect as transport errors
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "tool not found",
+			err:      errors.New("tool not found: foo.bar"),
+			expected: false,
+		},
+		{
+			name:     "invalid arguments",
+			err:      errors.New("invalid arguments: missing required field"),
+			expected: false,
+		},
+		{
+			name:     "server config not found",
+			err:      errors.New("server config not found: playwright"),
+			expected: false,
+		},
+		{
+			name:     "permission denied",
+			err:      errors.New("permission denied"),
+			expected: false,
+		},
+		{
+			name:     "file not found",
+			err:      errors.New("open /path/to/file: no such file or directory"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransportError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isTransportError(%v) = %v, want %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveClient(t *testing.T) {
+	// Create a registry with no servers (we just test the mechanics)
+	registry := NewServerRegistry(nil)
+
+	// Removing a non-existent client should not panic
+	registry.RemoveClient("nonexistent")
+
+	// The registry should still be functional
+	if registry.clients == nil {
+		t.Error("Registry clients map should not be nil after RemoveClient")
+	}
+}


### PR DESCRIPTION
## Problem

When a backend MCP server dies or crashes (e.g., via `pkill -f playwright`), subsequent tool calls through the proxy fail with "broken pipe" or "context deadline exceeded" errors. The proxy caches the dead connection and never attempts to reconnect, requiring the user to restart the entire Claude Code session.

### Reproduction Steps
1. Start a Claude Code session with lazy-mcp-proxy
2. Execute a tool (e.g., `playwright.browser_navigate`)
3. Kill the backend process: `pkill -f "@playwright/mcp"`
4. Execute another tool
5. **Expected**: Tool succeeds (after brief reconnection delay)
6. **Actual**: "broken pipe" error, all subsequent calls fail

## Solution

Implement error-triggered cache invalidation with automatic retry:

1. **`isTransportError()` helper**: Detects transport-level errors (broken pipe, connection reset, EOF, etc.)
2. **`RemoveClient()` method**: Removes stale client from ServerRegistry cache
3. **Retry logic in `HandleExecuteTool()`**: On transport error, removes stale client and retries once with fresh connection
4. **Increased timeout**: 15s → 30s to accommodate reconnection overhead

### How it works

```
First attempt → Transport error detected → Remove stale client → Retry → Success
```

The fix provides transparent recovery - users see a brief delay instead of permanent failure.

## Testing

- Added unit tests for `isTransportError()` (17 test cases)
- Added unit test for `RemoveClient()` mechanics
- Manually tested kill/reconnect scenario with playwright backend

```bash
go test ./internal/hierarchy/... -v
# All tests pass
```

## Changes

- `internal/hierarchy/hierarchy.go`: Added transport error detection, cache invalidation, and retry logic
- `internal/hierarchy/transport_error_test.go`: Unit tests (new file)