### PR TITLE
fix: Auto-reconnect on backend server crash (v2 - rebased)

### DIFF
--- a/internal/hierarchy/hierarchy.go
+++ b/internal/hierarchy/hierarchy.go
@@ -399,6 +399,8 @@ func (h *Hierarchy) ResolveToolPath(toolPath string) (*ToolDefinition, string, e
 }
 
 // HandleExecuteTool handles the execute_tool meta-tool
+// Implements automatic retry with reconnection on transport errors (broken pipe, connection reset, etc.)
+// Note: Timeout errors (context deadline exceeded) do NOT trigger retry to avoid duplicate operations.
 func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegistry, toolPath string, arguments map[string]interface{}) (*mcp.CallToolResult, error) {
 	// Resolve the tool path to get tool definition and server name
 	toolDef, serverName, err := h.ResolveToolPath(toolPath)
@@ -410,42 +412,78 @@ func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegis
 		return nil, fmt.Errorf("no MCP server configured for tool: %s", toolPath)
 	}
 
-	// Get or load the MCP client for this server
-	client, err := registry.GetOrLoadServer(ctx, serverName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get MCP client: %w", err)
-	}
-
 	// Use the mapped tool name
 	actualToolName := toolDef.MapsTo
 	if actualToolName == "" {
 		actualToolName = strings.Split(toolPath, ".")[len(strings.Split(toolPath, "."))-1]
 	}
 
-	log.Printf("Executing tool: hierarchy_path=%s, server=%s, tool=%s", toolPath, serverName, actualToolName)
+	// Retry config: max 2 attempts (initial + 1 retry) for transport errors only
+	const maxAttempts = 2
+	var lastErr error
 
-	// Create a context with 30-second timeout for tool execution
-	// (increased from 15s to account for queuing time when serializing requests)
-	// Note: We create the timeout BEFORE acquiring the lock to enforce a total deadline
-	// for the operation. If we waited for the lock first, a client could hang indefinitely.
-	toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			log.Printf("Retrying tool execution after transport error (attempt %d/%d): %s", attempt+1, maxAttempts, toolPath)
+		}
 
-	// Serialize tool calls to the same server to prevent concurrent stdio access.
-	// Stdio is a single-channel transport that cannot handle interleaved messages.
-	// See: https://github.com/voicetreelab/lazy-mcp/issues/8
-	mutex := registry.GetClientMutex(serverName)
-	mutex.Lock()
-	defer mutex.Unlock()
+		// Get or load the MCP client for this server (inside loop for fresh connection on retry)
+		mcpClient, err := registry.GetOrLoadServer(ctx, serverName)
+		if err != nil {
+			// GetOrLoadServer failure is not retryable (config issue, not transport)
+			return nil, fmt.Errorf("failed to get MCP client: %w", err)
+		}
 
-	// Call the tool on the actual MCP server
-	callRequest := mcp.CallToolRequest{}
-	callRequest.Params.Name = actualToolName
-	callRequest.Params.Arguments = arguments
+		log.Printf("Executing tool: hierarchy_path=%s, server=%s, tool=%s (attempt %d/%d)", toolPath, serverName, actualToolName, attempt+1, maxAttempts)
 
-	result, err := client.GetClient().CallTool(toolCtx, callRequest)
-	if err != nil {
-		// Include inputSchema in error message to help LLMs self-correct parameter mistakes
+		// Per-attempt timeout for tool execution (does not include retry time)
+		// Note: We create the timeout BEFORE acquiring the lock to enforce a total deadline
+		// for the operation. If we waited for the lock first, a client could hang indefinitely.
+		toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+		// Serialize tool calls to the same server to prevent concurrent stdio access.
+		// Stdio is a single-channel transport that cannot handle interleaved messages.
+		// See: https://github.com/voicetreelab/lazy-mcp/issues/8
+		mutex := registry.GetClientMutex(serverName)
+		mutex.Lock()
+
+		// Call the tool on the actual MCP server
+		callRequest := mcp.CallToolRequest{}
+		callRequest.Params.Name = actualToolName
+		callRequest.Params.Arguments = arguments
+
+		result, err := mcpClient.GetClient().CallTool(toolCtx, callRequest)
+		cancel() // Clean up context
+		mutex.Unlock()
+
+		if err == nil {
+			// Success - check if result has IsError set, append schema to help LLMs self-correct
+			if result != nil && result.IsError && toolDef.InputSchema != nil && len(result.Content) > 0 {
+				schemaJSON, marshalErr := json.MarshalIndent(toolDef.InputSchema, "", "  ")
+				if marshalErr == nil {
+					// Append schema to the first text content item
+					// Note: TextContent is a value type, so we modify the copy and assign it back to the slice
+					if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+						textContent.Text += fmt.Sprintf("\n\nExpected inputSchema:\n%s", string(schemaJSON))
+						result.Content[0] = textContent
+					}
+				}
+			}
+			return result, nil
+		}
+
+		lastErr = err
+
+		// Check if this is a transport error (broken pipe, connection reset, etc.)
+		if isTransportError(err) {
+			log.Printf("Transport error detected for server %s: %v", serverName, err)
+			// Remove the stale client from cache so next attempt gets a fresh connection
+			registry.RemoveClient(serverName)
+			// Continue to retry
+			continue
+		}
+
+		// Non-transport error, don't retry - include inputSchema in error message
 		if toolDef.InputSchema != nil {
 			schemaJSON, marshalErr := json.MarshalIndent(toolDef.InputSchema, "", "  ")
 			if marshalErr == nil {
@@ -455,19 +493,14 @@ func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegis
 		return nil, fmt.Errorf("failed to call tool %s: %w", actualToolName, err)
 	}
 
-	// Check if result has IsError set - append schema to help LLMs self-correct
-	if result != nil && result.IsError && toolDef.InputSchema != nil && len(result.Content) > 0 {
+	// All retries exhausted
+	if toolDef.InputSchema != nil {
 		schemaJSON, marshalErr := json.MarshalIndent(toolDef.InputSchema, "", "  ")
 		if marshalErr == nil {
-			// Append schema to the first text content item
-			// Note: TextContent is a value type, so we modify the copy and assign it back to the slice
-			if textContent, ok := result.Content[0].(mcp.TextContent); ok {
-				textContent.Text += fmt.Sprintf("\n\nExpected inputSchema:\n%s", string(schemaJSON))
-				result.Content[0] = textContent
-			}
+			return nil, fmt.Errorf("failed to call tool %s after retry: %w\n\nExpected inputSchema:\n%s", actualToolName, lastErr, string(schemaJSON))
 		}
 	}
-	return result, nil
+	return nil, fmt.Errorf("failed to call tool %s after retry: %w", actualToolName, lastErr)
 }
 
 // ServerRegistry manages MCP client connections
@@ -581,4 +614,52 @@ func (r *ServerRegistry) Close() {
 	// Clear the clients and mutex maps
 	r.clients = make(map[string]*client.Client)
 	r.clientMutex = make(map[string]*sync.Mutex)
+}
+
+// RemoveClient removes a client from the registry, allowing it to be reconnected.
+// This is used when a transport error is detected to force a fresh connection.
+//
+// Race condition note: If another goroutine is using this client while RemoveClient
+// is called, the client will be closed mid-operation. This is safe because:
+// 1. The operation will fail with "use of closed network connection"
+// 2. This error is classified as a transport error, triggering a retry
+// 3. The retry will get a fresh connection via GetOrLoadServer
+func (r *ServerRegistry) RemoveClient(serverName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if client, exists := r.clients[serverName]; exists {
+		log.Printf("Removing stale MCP client from cache: %s", serverName)
+		_ = client.Close()
+		delete(r.clients, serverName)
+	}
+}
+
+// isTransportError checks if an error is a transport-level error indicating
+// the connection is dead (broken pipe, connection reset, EOF, etc.)
+// Note: "context deadline exceeded" is NOT considered a transport error because:
+// 1. The server may still be processing the request (risk of duplicate operations)
+// 2. Retrying a slow operation won't help if the server is overloaded
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	// Transport error patterns indicating dead connection
+	// Note: "broken pipe" matches "write: broken pipe", "connection reset" matches "read: connection reset"
+	transportErrors := []string{
+		"broken pipe",
+		"connection reset",
+		"connection refused",
+		"eof",
+		"use of closed network connection",
+		"no such host",
+		"transport endpoint is not connected",
+	}
+	for _, pattern := range transportErrors {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hierarchy/transport_error_test.go
+++ b/internal/hierarchy/transport_error_test.go
@@ -1,0 +1,128 @@
+package hierarchy
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsTransportError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		// Should detect as transport errors
+		{
+			name:     "broken pipe",
+			err:      errors.New("write: broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "EOF",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			name:     "closed network connection",
+			err:      errors.New("use of closed network connection"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "transport endpoint not connected",
+			err:      errors.New("transport endpoint is not connected"),
+			expected: true,
+		},
+		{
+			name:     "no such host",
+			err:      errors.New("dial tcp: lookup foo: no such host"),
+			expected: true,
+		},
+		// Case insensitivity
+		{
+			name:     "BROKEN PIPE uppercase",
+			err:      errors.New("BROKEN PIPE"),
+			expected: true,
+		},
+		// Should NOT detect as transport errors
+		// IMPORTANT: Timeout errors are NOT transport errors because:
+		// 1. The server may still be processing (risk of duplicate operations)
+		// 2. Retrying a slow operation won't help if server is overloaded
+		{
+			name:     "context deadline exceeded - NOT a transport error",
+			err:      errors.New("context deadline exceeded"),
+			expected: false, // Changed from true - retrying could cause duplicates!
+		},
+		{
+			name:     "i/o timeout - NOT a transport error",
+			err:      errors.New("i/o timeout"),
+			expected: false, // Changed from true - server may still be working
+		},
+		{
+			name:     "connection timed out - NOT a transport error",
+			err:      errors.New("dial tcp: connection timed out"),
+			expected: false, // Changed from true - could be temporary network issue
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "tool not found",
+			err:      errors.New("tool not found: foo.bar"),
+			expected: false,
+		},
+		{
+			name:     "invalid arguments",
+			err:      errors.New("invalid arguments: missing required field"),
+			expected: false,
+		},
+		{
+			name:     "server config not found",
+			err:      errors.New("server config not found: playwright"),
+			expected: false,
+		},
+		{
+			name:     "permission denied",
+			err:      errors.New("permission denied"),
+			expected: false,
+		},
+		{
+			name:     "file not found",
+			err:      errors.New("open /path/to/file: no such file or directory"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransportError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isTransportError(%v) = %v, want %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveClient(t *testing.T) {
+	// Create a registry with no servers (we just test the mechanics)
+	registry := NewServerRegistry(nil)
+
+	// Removing a non-existent client should not panic
+	registry.RemoveClient("nonexistent")
+
+	// The registry should still be functional
+	if registry.clients == nil {
+		t.Error("Registry clients map should not be nil after RemoveClient")
+	}
+}


### PR DESCRIPTION
## Summary

Rebased version of PR #11 that integrates with the mutex serialization from PR #10.

When a backend MCP server dies or crashes, subsequent tool calls would fail with "broken pipe" or "connection reset" errors. The proxy cached the dead connection and never attempted to reconnect.

## Changes

- Add `isTransportError()` helper to detect transport-level errors
- Add `RemoveClient()` method to ServerRegistry for cache invalidation
- Modify `HandleExecuteTool()` to retry once with fresh connection on transport error
- Integrate with mutex serialization (from main) for stdio safety

## Important Design Decision

**Timeout errors do NOT trigger retry** to avoid duplicate operations:

| Error Type | Retry? | Reason |
|------------|--------|--------|
| `broken pipe` | ✅ Yes | Connection dead |
| `connection reset` | ✅ Yes | Connection dead |
| `EOF` | ✅ Yes | Connection dead |
| `use of closed network connection` | ✅ Yes | Connection dead |
| `context deadline exceeded` | ❌ No | Server may still be processing |
| `i/o timeout` | ❌ No | Server may still be working |
| `connection timed out` | ❌ No | Temporary network issue |

## Review Comments Addressed (from PR #11)

| Comment | Status |
|---------|--------|
| Race condition | ✅ Documented - safe by design (fail-fast with retry) |
| Context deadline shouldn't trigger retry | ✅ Fixed |
| Redundant patterns | ✅ Fixed |
| Timeout comment misleading | ✅ Fixed |

## Test Plan

- [x] Unit tests pass (`go test ./internal/hierarchy/...`)
- [ ] Manual test: Kill backend server mid-operation, verify retry works
- [ ] Manual test: Timeout scenario doesn't cause duplicate operations

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)