### PR TITLE
feat: Auto-reconnect and observability tools (combined)

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,239 @@
+# MCP Proxy Observability
+
+The lazy-mcp proxy includes built-in observability tools that allow agents to self-diagnose performance issues, timeouts, and errors without requiring external monitoring infrastructure.
+
+## Overview
+
+Two MCP tools are provided:
+
+| Tool | Description |
+|------|-------------|
+| `proxy_doctor` | Run health checks and get actionable suggestions (like `/doctor` command) |
+| `get_proxy_metrics` | Get detailed latency percentiles, error rates, and recent errors |
+
+## Quick Start
+
+### Check Proxy Health
+
+```
+Agent: Let me check if there are any issues with the MCP proxy.
+[calls proxy_doctor]
+
+Response:
+{
+  "status": "warning",
+  "checks": [
+    {"name": "server_connectivity", "status": "pass", "message": "All 4 servers responding"},
+    {"name": "latency", "status": "warning", "message": "google-calendar p99=45.1s"},
+    {"name": "timeouts", "status": "fail", "message": "2 timeouts in last hour"},
+    {"name": "error_rate", "status": "pass", "message": "Error rate 4.3%"},
+    {"name": "memory", "status": "pass", "message": "Metrics store using ~0.2MB"}
+  ],
+  "suggestions": [
+    "google-calendar: Consider using smaller parameters for list-events"
+  ]
+}
+```
+
+### Get Detailed Metrics
+
+```
+Agent: Show me the performance metrics for the last hour.
+[calls get_proxy_metrics with since="1h"]
+
+Response:
+{
+  "time_window": "1h",
+  "summary": {
+    "total_calls": 47,
+    "success_rate": "95.7%",
+    "timeout_count": 2,
+    "active_servers": 4
+  },
+  "by_server": {
+    "google-calendar": {
+      "calls": 12,
+      "success": 10,
+      "timeouts": 2,
+      "latency": {"p50": "2.3s", "p95": "15.2s", "p99": "45.1s"},
+      "slowest_tool": "calendar.list-events",
+      "last_error": "context deadline exceeded"
+    },
+    "gmail": {
+      "calls": 20,
+      "success": 20,
+      "timeouts": 0,
+      "latency": {"p50": "0.8s", "p95": "1.2s", "p99": "1.5s"}
+    }
+  },
+  "recent_errors": [...]
+}
+```
+
+## Configuration
+
+Add these options to your proxy config under `mcpProxy.options`:
+
+```json
+{
+  "mcpProxy": {
+    "options": {
+      "metricsEnabled": true,
+      "metricsRetention": "8h",
+      "metricsFile": ""
+    }
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `metricsEnabled` | `true` | Enable/disable metrics collection |
+| `metricsRetention` | `"8h"` | How long to keep metrics (e.g., "1h", "8h", "24h", "7d") |
+| `metricsFile` | `""` | Path to persist metrics (empty = in-memory only) |
+
+## Tool Reference
+
+### proxy_doctor
+
+Runs comprehensive health checks and returns actionable diagnostics.
+
+**Input Schema:**
+```json
+{
+  "type": "object",
+  "properties": {}
+}
+```
+
+**Health Checks:**
+
+| Check | Description | Thresholds |
+|-------|-------------|------------|
+| `server_connectivity` | Verifies all configured servers are connected | Pass if all responding |
+| `latency` | Checks p99 latency per server | Warning: >30s, Critical: >45s |
+| `timeouts` | Counts timeout events | Warning: ≥2, Critical: ≥4 |
+| `error_rate` | Overall error percentage | Warning: >5%, Critical: >10% |
+| `memory` | Metrics store memory usage | Informational |
+
+### get_proxy_metrics
+
+Returns detailed performance metrics with filtering options.
+
+**Input Schema:**
+```json
+{
+  "type": "object",
+  "properties": {
+    "server": {
+      "type": "string",
+      "description": "Filter by server name (optional)"
+    },
+    "since": {
+      "type": "string",
+      "description": "Time window: '1h', '24h', '7d' (default: '1h')"
+    }
+  }
+}
+```
+
+## Architecture
+
+### Data Flow
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                        lazy-mcp-proxy                               │
+│                                                                     │
+│  ┌─────────────┐         ┌─────────────────────────────────────┐   │
+│  │ Tool Call   │         │          Metrics Store              │   │
+│  │ execute_tool│────────▶│                                     │   │
+│  │             │ record  │  ToolCall{                          │   │
+│  └─────────────┘         │    Server: "gmail"                  │   │
+│                          │    ToolPath: "gmail.search_emails"  │   │
+│                          │    Duration: 234ms                  │   │
+│                          │    Success: true                    │   │
+│                          │  }                                  │   │
+│                          │                                     │   │
+│                          │  ServerStats{                       │   │
+│                          │    Name: "gmail"                    │   │
+│                          │    ColdStartMs: 812                 │   │
+│                          │    IsConnected: true                │   │
+│                          │  }                                  │   │
+│                          └─────────────────────────────────────┘   │
+│                                      │                              │
+│                                      ▼                              │
+│  ┌───────────────────────────────────────────────────────────────┐ │
+│  │                       MCP Tools                                │ │
+│  │                                                                │ │
+│  │  proxy_doctor              get_proxy_metrics                   │ │
+│  │  ├─ server_connectivity    ├─ latency percentiles (p50/95/99) │ │
+│  │  ├─ latency check          ├─ success/error rates             │ │
+│  │  ├─ timeout check          ├─ per-server breakdown            │ │
+│  │  ├─ error_rate check       └─ recent errors list              │ │
+│  │  └─ actionable suggestions                                     │ │
+│  └───────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+└─────────────────────────────────────┬───────────────────────────────┘
+                                      │
+                                      ▼
+┌────────────────────────────────────────────────────────────────────┐
+│                         Agent (Claude)                              │
+│                                                                     │
+│  "Something seems slow" → proxy_doctor → "gmail p99=45s, suggest   │
+│                                           using smaller queries"   │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Instrumentation Points
+
+Metrics are collected at two key points:
+
+1. **Tool Execution** (`hierarchy.go:HandleExecuteTool`)
+   ```go
+   startTime := time.Now()
+   result, err := client.CallTool(ctx, request)
+   metricsStore.RecordCall(server, tool, time.Since(startTime), err)
+   ```
+
+2. **Server Loading** (`hierarchy.go:GetOrLoadServer`)
+   ```go
+   startTime := time.Now()
+   client := NewMCPClient(config)
+   client.Initialize(ctx)
+   metricsStore.RecordServerLoad(name, time.Since(startTime).Milliseconds())
+   ```
+
+### Why Zero Dependencies?
+
+| Approach | Agent Can Self-Diagnose? | Setup Required |
+|----------|-------------------------|----------------|
+| **This (Zero-Dep)** | ✅ Yes - via MCP tools | None |
+| Prometheus | ❌ No - needs human + Grafana | Significant |
+| OpenTelemetry | ❌ No - needs collector + backend | Significant |
+
+The key insight: **agents need to diagnose issues themselves**, not wait for human operators. This requires observability exposed via MCP tools.
+
+## Design Principles
+
+1. **Zero Dependencies** - No Prometheus, Grafana, or external services required
+2. **Works Immediately** - Agents can query metrics out of the box
+3. **Self-Diagnosing** - Agents understand issues and suggest fixes
+4. **Lightweight** - In-memory with auto-pruning, <1MB memory footprint
+5. **Optional Persistence** - Set `metricsFile` to survive restarts
+
+## Tip: Enable Persistence
+
+For debugging across proxy restarts, enable metrics persistence:
+
+```json
+{
+  "mcpProxy": {
+    "options": {
+      "metricsFile": "~/.cache/lazy-mcp-metrics.json"
+    }
+  }
+}
+```
+
+Without persistence, metrics are lost when the proxy restarts, making it harder to debug issues that occurred in previous sessions.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/voicetreelab/lazy-mcp/internal/config"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/voicetreelab/lazy-mcp/internal/config"
 )
 
 type Client struct {
@@ -32,6 +32,16 @@ type Client struct {
 	lazyTemplates []mcp.ResourceTemplate
 	activateOnce  sync.Once
 	activated     bool
+}
+
+// NewClientFromMCP wraps an existing mark3labs/mcp-go client.
+// Used by tests that inject mock transports to exercise reconnect paths
+// without spawning real stdio/SSE backends.
+func NewClientFromMCP(name string, mcpClient *client.Client) *Client {
+	return &Client{
+		name:   name,
+		client: mcpClient,
+	}
 }
 
 func NewMCPClient(name string, conf *config.MCPClientConfigV2) (*Client, error) {
@@ -217,12 +227,12 @@ func (c *Client) activateTools(ctx context.Context, request mcp.CallToolRequest)
 
 	// Return success response
 	response := map[string]interface{}{
-		"activated":      true,
-		"server":         c.name,
-		"toolCount":      toolCount,
-		"promptCount":    promptCount,
-		"resourceCount":  resourceCount,
-		"templateCount":  templateCount,
+		"activated":     true,
+		"server":        c.name,
+		"toolCount":     toolCount,
+		"promptCount":   promptCount,
+		"resourceCount": resourceCount,
+		"templateCount": templateCount,
 	}
 
 	jsonBytes, err := json.Marshal(response)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,11 @@ type OptionsV2 struct {
 	RecursiveLazyLoad optional.Field[bool] `json:"recursiveLazyLoad,omitempty"`
 	AuthTokens        []string             `json:"authTokens,omitempty"`
 	ToolFilter        *ToolFilterConfig    `json:"toolFilter,omitempty"`
+
+	// Observability options
+	MetricsEnabled   optional.Field[bool] `json:"metricsEnabled,omitempty"`   // Enable metrics collection (default: true)
+	MetricsRetention string               `json:"metricsRetention,omitempty"` // Retention period: "1h", "8h", "24h", "7d" (default: "8h")
+	MetricsFile      string               `json:"metricsFile,omitempty"`      // Persistence file path (default: "" = in-memory only)
 }
 
 type MCPProxyConfigV2 struct {

--- a/internal/hierarchy/hierarchy.go
+++ b/internal/hierarchy/hierarchy.go
@@ -520,6 +520,9 @@ type ServerRegistry struct {
 	serverConfigs map[string]*config.MCPClientConfigV2
 	metricsStore  *metrics.Store
 	mu            sync.RWMutex
+	// createClient optionally overrides client.NewMCPClient. Intended for tests
+	// that inject mock transports; nil means use the production constructor.
+	createClient func(name string, conf *config.MCPClientConfigV2) (*client.Client, error)
 }
 
 // NewServerRegistry creates a new server registry with server configurations
@@ -579,8 +582,14 @@ func (r *ServerRegistry) GetOrLoadServer(ctx context.Context, serverName string)
 		return nil, fmt.Errorf("server config not found: %s", serverName)
 	}
 
-	// Create the MCP client
-	mcpClient, err := client.NewMCPClient(serverName, cfg)
+	// Create the MCP client (tests may override via createClient)
+	var mcpClient *client.Client
+	var err error
+	if r.createClient != nil {
+		mcpClient, err = r.createClient(serverName, cfg)
+	} else {
+		mcpClient, err = client.NewMCPClient(serverName, cfg)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MCP client: %w", err)
 	}

--- a/internal/hierarchy/hierarchy.go
+++ b/internal/hierarchy/hierarchy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/voicetreelab/lazy-mcp/internal/client"
 	"github.com/voicetreelab/lazy-mcp/internal/config"
+	"github.com/voicetreelab/lazy-mcp/internal/metrics"
 )
 
 // HierarchyNode represents a node in the tool hierarchy
@@ -399,6 +400,8 @@ func (h *Hierarchy) ResolveToolPath(toolPath string) (*ToolDefinition, string, e
 }
 
 // HandleExecuteTool handles the execute_tool meta-tool
+// Implements automatic retry with reconnection on transport errors (broken pipe, connection reset, etc.)
+// Note: Timeout errors (context deadline exceeded) do NOT trigger retry to avoid duplicate operations.
 func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegistry, toolPath string, arguments map[string]interface{}) (*mcp.CallToolResult, error) {
 	// Resolve the tool path to get tool definition and server name
 	toolDef, serverName, err := h.ResolveToolPath(toolPath)
@@ -410,42 +413,87 @@ func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegis
 		return nil, fmt.Errorf("no MCP server configured for tool: %s", toolPath)
 	}
 
-	// Get or load the MCP client for this server
-	client, err := registry.GetOrLoadServer(ctx, serverName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get MCP client: %w", err)
-	}
-
 	// Use the mapped tool name
 	actualToolName := toolDef.MapsTo
 	if actualToolName == "" {
 		actualToolName = strings.Split(toolPath, ".")[len(strings.Split(toolPath, "."))-1]
 	}
 
-	log.Printf("Executing tool: hierarchy_path=%s, server=%s, tool=%s", toolPath, serverName, actualToolName)
+	// Retry config: max 2 attempts (initial + 1 retry) for transport errors only
+	const maxAttempts = 2
+	var lastErr error
 
-	// Create a context with 30-second timeout for tool execution
-	// (increased from 15s to account for queuing time when serializing requests)
-	// Note: We create the timeout BEFORE acquiring the lock to enforce a total deadline
-	// for the operation. If we waited for the lock first, a client could hang indefinitely.
-	toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			log.Printf("Retrying tool execution after transport error (attempt %d/%d): %s", attempt+1, maxAttempts, toolPath)
+		}
 
-	// Serialize tool calls to the same server to prevent concurrent stdio access.
-	// Stdio is a single-channel transport that cannot handle interleaved messages.
-	// See: https://github.com/voicetreelab/lazy-mcp/issues/8
-	mutex := registry.GetClientMutex(serverName)
-	mutex.Lock()
-	defer mutex.Unlock()
+		// Get or load the MCP client for this server (inside loop for fresh connection on retry)
+		mcpClient, err := registry.GetOrLoadServer(ctx, serverName)
+		if err != nil {
+			// GetOrLoadServer failure is not retryable (config issue, not transport)
+			return nil, fmt.Errorf("failed to get MCP client: %w", err)
+		}
 
-	// Call the tool on the actual MCP server
-	callRequest := mcp.CallToolRequest{}
-	callRequest.Params.Name = actualToolName
-	callRequest.Params.Arguments = arguments
+		log.Printf("Executing tool: hierarchy_path=%s, server=%s, tool=%s (attempt %d/%d)", toolPath, serverName, actualToolName, attempt+1, maxAttempts)
 
-	result, err := client.GetClient().CallTool(toolCtx, callRequest)
-	if err != nil {
-		// Include inputSchema in error message to help LLMs self-correct parameter mistakes
+		// Per-attempt timeout for tool execution (does not include retry time)
+		// Note: We create the timeout BEFORE acquiring the lock to enforce a total deadline
+		// for the operation. If we waited for the lock first, a client could hang indefinitely.
+		toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+		// Serialize tool calls to the same server to prevent concurrent stdio access.
+		// Stdio is a single-channel transport that cannot handle interleaved messages.
+		// See: https://github.com/voicetreelab/lazy-mcp/issues/8
+		mutex := registry.GetClientMutex(serverName)
+		mutex.Lock()
+
+		// Track execution time for metrics
+		startTime := time.Now()
+
+		// Call the tool on the actual MCP server
+		callRequest := mcp.CallToolRequest{}
+		callRequest.Params.Name = actualToolName
+		callRequest.Params.Arguments = arguments
+
+		result, err := mcpClient.GetClient().CallTool(toolCtx, callRequest)
+		duration := time.Since(startTime)
+		cancel() // Clean up context
+		mutex.Unlock()
+
+		// Record metrics for this attempt
+		if registry.metricsStore != nil {
+			registry.metricsStore.RecordCall(serverName, toolPath, duration, err)
+		}
+
+		if err == nil {
+			// Success - check if result has IsError set, append schema to help LLMs self-correct
+			if result != nil && result.IsError && toolDef.InputSchema != nil && len(result.Content) > 0 {
+				schemaJSON, marshalErr := json.MarshalIndent(toolDef.InputSchema, "", "  ")
+				if marshalErr == nil {
+					// Append schema to the first text content item
+					// Note: TextContent is a value type, so we modify the copy and assign it back to the slice
+					if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+						textContent.Text += fmt.Sprintf("\n\nExpected inputSchema:\n%s", string(schemaJSON))
+						result.Content[0] = textContent
+					}
+				}
+			}
+			return result, nil
+		}
+
+		lastErr = err
+
+		// Check if this is a transport error (broken pipe, connection reset, etc.)
+		if isTransportError(err) {
+			log.Printf("Transport error detected for server %s: %v", serverName, err)
+			// Remove the stale client from cache so next attempt gets a fresh connection
+			registry.RemoveClient(serverName)
+			// Continue to retry
+			continue
+		}
+
+		// Non-transport error, don't retry - include inputSchema in error message
 		if toolDef.InputSchema != nil {
 			schemaJSON, marshalErr := json.MarshalIndent(toolDef.InputSchema, "", "  ")
 			if marshalErr == nil {
@@ -455,19 +503,14 @@ func (h *Hierarchy) HandleExecuteTool(ctx context.Context, registry *ServerRegis
 		return nil, fmt.Errorf("failed to call tool %s: %w", actualToolName, err)
 	}
 
-	// Check if result has IsError set - append schema to help LLMs self-correct
-	if result != nil && result.IsError && toolDef.InputSchema != nil && len(result.Content) > 0 {
+	// All retries exhausted
+	if toolDef.InputSchema != nil {
 		schemaJSON, marshalErr := json.MarshalIndent(toolDef.InputSchema, "", "  ")
 		if marshalErr == nil {
-			// Append schema to the first text content item
-			// Note: TextContent is a value type, so we modify the copy and assign it back to the slice
-			if textContent, ok := result.Content[0].(mcp.TextContent); ok {
-				textContent.Text += fmt.Sprintf("\n\nExpected inputSchema:\n%s", string(schemaJSON))
-				result.Content[0] = textContent
-			}
+			return nil, fmt.Errorf("failed to call tool %s after retry: %w\n\nExpected inputSchema:\n%s", actualToolName, lastErr, string(schemaJSON))
 		}
 	}
-	return result, nil
+	return nil, fmt.Errorf("failed to call tool %s after retry: %w", actualToolName, lastErr)
 }
 
 // ServerRegistry manages MCP client connections
@@ -475,6 +518,7 @@ type ServerRegistry struct {
 	clients       map[string]*client.Client
 	clientMutex   map[string]*sync.Mutex // Per-client mutex for serializing tool calls
 	serverConfigs map[string]*config.MCPClientConfigV2
+	metricsStore  *metrics.Store
 	mu            sync.RWMutex
 }
 
@@ -502,6 +546,11 @@ func (r *ServerRegistry) GetClientMutex(serverName string) *sync.Mutex {
 	m := &sync.Mutex{}
 	r.clientMutex[serverName] = m
 	return m
+}
+
+// SetMetricsStore sets the metrics store for recording tool call metrics
+func (r *ServerRegistry) SetMetricsStore(store *metrics.Store) {
+	r.metricsStore = store
 }
 
 // GetOrLoadServer gets an existing client or creates and initializes a new one
@@ -581,4 +630,52 @@ func (r *ServerRegistry) Close() {
 	// Clear the clients and mutex maps
 	r.clients = make(map[string]*client.Client)
 	r.clientMutex = make(map[string]*sync.Mutex)
+}
+
+// RemoveClient removes a client from the registry, allowing it to be reconnected.
+// This is used when a transport error is detected to force a fresh connection.
+//
+// Race condition note: If another goroutine is using this client while RemoveClient
+// is called, the client will be closed mid-operation. This is safe because:
+// 1. The operation will fail with "use of closed network connection"
+// 2. This error is classified as a transport error, triggering a retry
+// 3. The retry will get a fresh connection via GetOrLoadServer
+func (r *ServerRegistry) RemoveClient(serverName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if client, exists := r.clients[serverName]; exists {
+		log.Printf("Removing stale MCP client from cache: %s", serverName)
+		_ = client.Close()
+		delete(r.clients, serverName)
+	}
+}
+
+// isTransportError checks if an error is a transport-level error indicating
+// the connection is dead (broken pipe, connection reset, EOF, etc.)
+// Note: "context deadline exceeded" is NOT considered a transport error because:
+// 1. The server may still be processing the request (risk of duplicate operations)
+// 2. Retrying a slow operation won't help if the server is overloaded
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	// Transport error patterns indicating dead connection
+	// Note: "broken pipe" matches "write: broken pipe", "connection reset" matches "read: connection reset"
+	transportErrors := []string{
+		"broken pipe",
+		"connection reset",
+		"connection refused",
+		"eof",
+		"use of closed network connection",
+		"no such host",
+		"transport endpoint is not connected",
+	}
+	for _, pattern := range transportErrors {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hierarchy/reconnect_integration_test.go
+++ b/internal/hierarchy/reconnect_integration_test.go
@@ -1,0 +1,312 @@
+package hierarchy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	lazyclient "github.com/voicetreelab/lazy-mcp/internal/client"
+	"github.com/voicetreelab/lazy-mcp/internal/config"
+)
+
+// reconnectMockTransport implements mcp-go's transport.Interface for tests.
+//
+// Coverage honesty:
+//   - Exercises HandleExecuteTool's retry loop: isTransportError classification,
+//     RemoveClient (evict + Close), GetOrLoadServer creating a fresh client, and
+//     a successful second CallTool attempt.
+//   - Uses a mock transport behind a real mark3labs/mcp-go Client (so CallTool /
+//     Initialize / Close go through the real client path).
+//   - Does NOT exercise real MCP stdio/SSE/HTTP transports, process spawning,
+//     or OS-level broken-pipe from a dead subprocess.
+type reconnectMockTransport struct {
+	mu sync.Mutex
+
+	// failNextToolsCalls is how many tools/call requests should fail before success.
+	// Shared across generations when tests use a shared counter instead; per-instance
+	// field is used when each client owns its own fail budget.
+	failNextToolsCalls int
+	failErr            error
+
+	toolsCallCount atomic.Int32
+	closed         atomic.Bool
+	closeCount     atomic.Int32
+
+	// optional shared counters for multi-client reconnect scenarios
+	sharedToolsCalls *atomic.Int32
+	// failWhileSharedBelow: fail tools/call while *sharedToolsCalls <= this value
+	// (checked after increment). 0 means use per-instance failNextToolsCalls only.
+	failWhileSharedBelow int32
+}
+
+func newReconnectMockTransport(failErr error, failNextToolsCalls int) *reconnectMockTransport {
+	if failErr == nil {
+		failErr = errors.New("write: broken pipe")
+	}
+	return &reconnectMockTransport{
+		failErr:            failErr,
+		failNextToolsCalls: failNextToolsCalls,
+	}
+}
+
+func (t *reconnectMockTransport) Start(context.Context) error { return nil }
+
+func (t *reconnectMockTransport) SendNotification(context.Context, mcp.JSONRPCNotification) error {
+	return nil
+}
+
+func (t *reconnectMockTransport) SetNotificationHandler(func(mcp.JSONRPCNotification)) {}
+
+func (t *reconnectMockTransport) GetSessionId() string { return "reconnect-mock" }
+
+func (t *reconnectMockTransport) Close() error {
+	t.closed.Store(true)
+	t.closeCount.Add(1)
+	return nil
+}
+
+func (t *reconnectMockTransport) SendRequest(ctx context.Context, request transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	switch request.Method {
+	case "initialize":
+		result, err := json.Marshal(map[string]any{
+			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+			"capabilities":    map[string]any{},
+			"serverInfo": map[string]any{
+				"name":    "reconnect-mock",
+				"version": "test",
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return transport.NewJSONRPCResultResponse(request.ID, result), nil
+
+	case "tools/call":
+		n := t.toolsCallCount.Add(1)
+		var sharedN int32
+		if t.sharedToolsCalls != nil {
+			sharedN = t.sharedToolsCalls.Add(1)
+		}
+
+		// Shared-counter mode (cross-client crash → reconnect)
+		if t.sharedToolsCalls != nil && t.failWhileSharedBelow > 0 {
+			if sharedN <= t.failWhileSharedBelow {
+				return nil, t.failErr
+			}
+		} else if int(n) <= t.failNextToolsCalls {
+			// Per-instance fail budget
+			return nil, t.failErr
+		}
+
+		result, err := json.Marshal(map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "recovered-ok"},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return transport.NewJSONRPCResultResponse(request.ID, result), nil
+
+	default:
+		return nil, fmt.Errorf("reconnectMockTransport: unexpected method %q", request.Method)
+	}
+}
+
+var _ transport.Interface = (*reconnectMockTransport)(nil)
+
+// TestHandleExecuteTool_TransportCrashAutoReconnect is the highest-fidelity
+// integration test the architecture allows without a real MCP subprocess.
+//
+// Flow under test:
+//  1. First CallTool returns a transport error ("broken pipe")
+//  2. isTransportError classifies it
+//  3. RemoveClient evicts the stale client and Close()s it
+//  4. Retry path GetOrLoadServer creates a fresh client (factory generation++)
+//  5. Second CallTool succeeds
+func TestHandleExecuteTool_TransportCrashAutoReconnect(t *testing.T) {
+	const serverName = "crashy-server"
+	const toolPath = "demo.echo"
+
+	var (
+		sharedToolsCalls atomic.Int32
+		createCount      atomic.Int32
+		closedTransports []*reconnectMockTransport
+		closeMu          sync.Mutex
+		clientsCreated   []*lazyclient.Client
+	)
+
+	makeClient := func(name string) (*lazyclient.Client, *reconnectMockTransport) {
+		tr := &reconnectMockTransport{
+			failErr:              errors.New("write: broken pipe"),
+			sharedToolsCalls:     &sharedToolsCalls,
+			failWhileSharedBelow: 1, // first tools/call across all clients fails
+		}
+		// Track Close via wrapper that records into closedTransports when closed
+		// (transport itself sets closed; we append on create and assert after)
+		closeMu.Lock()
+		closedTransports = append(closedTransports, tr)
+		closeMu.Unlock()
+
+		mcpCli := mcpclient.NewClient(tr)
+		wrapped := lazyclient.NewClientFromMCP(name, mcpCli)
+		clientsCreated = append(clientsCreated, wrapped)
+		return wrapped, tr
+	}
+
+	cfg := &config.MCPClientConfigV2{
+		TransportType: config.MCPClientTypeStdio,
+		Command:       "true", // unused; factory supplies clients
+		Options:       &config.OptionsV2{},
+	}
+	registry := NewServerRegistry(map[string]*config.MCPClientConfigV2{
+		serverName: cfg,
+	})
+	registry.createClient = func(name string, conf *config.MCPClientConfigV2) (*lazyclient.Client, error) {
+		createCount.Add(1)
+		c, _ := makeClient(name)
+		return c, nil
+	}
+
+	h := &Hierarchy{
+		nodes: map[string]*HierarchyNode{
+			"demo.echo": {
+				Tools: map[string]*ToolDefinition{
+					"echo": {
+						Description: "echo for reconnect test",
+						MapsTo:      "echo",
+						Server:      serverName,
+					},
+				},
+			},
+		},
+	}
+
+	// Sanity: the error we inject is classified as a transport error
+	if !isTransportError(errors.New("write: broken pipe")) {
+		t.Fatal("precondition: broken pipe should be a transport error")
+	}
+
+	ctx := context.Background()
+	result, err := h.HandleExecuteTool(ctx, registry, toolPath, map[string]interface{}{
+		"message": "hello",
+	})
+	if err != nil {
+		t.Fatalf("HandleExecuteTool should recover after reconnect: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil CallToolResult after recovery")
+	}
+	if result.IsError {
+		t.Fatalf("expected successful tool result, got IsError with content: %+v", result.Content)
+	}
+
+	// (a)+(d) two tools/call attempts: first crash, second success
+	if got := sharedToolsCalls.Load(); got != 2 {
+		t.Errorf("tools/call attempts = %d, want 2 (fail then succeed)", got)
+	}
+
+	// (c) two clients created: initial + reconnect
+	if got := createCount.Load(); got != 2 {
+		t.Errorf("client create count = %d, want 2 (initial + reconnect)", got)
+	}
+	if len(clientsCreated) != 2 {
+		t.Fatalf("clientsCreated len = %d, want 2", len(clientsCreated))
+	}
+	if clientsCreated[0] == clientsCreated[1] {
+		t.Error("reconnect should create a distinct client instance")
+	}
+
+	// (b) first client's transport was Closed via RemoveClient
+	firstTr := closedTransports[0]
+	if !firstTr.closed.Load() {
+		t.Error("RemoveClient should Close() the stale client's transport")
+	}
+	if firstTr.closeCount.Load() < 1 {
+		t.Error("expected Close() on stale transport")
+	}
+
+	// Registry holds the fresh (second) client
+	if registry.clients[serverName] != clientsCreated[1] {
+		t.Error("registry should hold the reconnected client")
+	}
+
+	// Text content from successful retry
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in successful result")
+	}
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] type = %T, want TextContent", result.Content[0])
+	}
+	if text.Text != "recovered-ok" {
+		t.Errorf("result text = %q, want %q", text.Text, "recovered-ok")
+	}
+}
+
+// TestHandleExecuteTool_NonTransportErrorNoRetry verifies application errors
+// do not trigger RemoveClient / reconnect.
+func TestHandleExecuteTool_NonTransportErrorNoRetry(t *testing.T) {
+	const serverName = "app-err-server"
+	const toolPath = "demo.fail"
+
+	var createCount atomic.Int32
+	var toolsCalls atomic.Int32
+
+	cfg := &config.MCPClientConfigV2{
+		TransportType: config.MCPClientTypeStdio,
+		Command:       "true",
+		Options:       &config.OptionsV2{},
+	}
+	registry := NewServerRegistry(map[string]*config.MCPClientConfigV2{
+		serverName: cfg,
+	})
+	registry.createClient = func(name string, conf *config.MCPClientConfigV2) (*lazyclient.Client, error) {
+		createCount.Add(1)
+		tr := &reconnectMockTransport{
+			// Reuse reconnectMockTransport with a non-transport failErr and a large fail budget
+			// (failNextToolsCalls: 99) so every tools/call returns a non-transport error → no retry.
+			failErr:            errors.New("invalid arguments: missing field"),
+			failNextToolsCalls: 99,
+			sharedToolsCalls:   &toolsCalls,
+			// failWhileSharedBelow 0 → per-instance budget of 99
+		}
+		// Force non-transport failure: failNextToolsCalls=99 means all calls fail
+		// with failErr which is NOT a transport error → no retry.
+		mcpCli := mcpclient.NewClient(tr)
+		return lazyclient.NewClientFromMCP(name, mcpCli), nil
+	}
+
+	h := &Hierarchy{
+		nodes: map[string]*HierarchyNode{
+			"demo.fail": {
+				Tools: map[string]*ToolDefinition{
+					"fail": {
+						Description: "always fails (app error)",
+						MapsTo:      "fail",
+						Server:      serverName,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := h.HandleExecuteTool(context.Background(), registry, toolPath, nil)
+	if err == nil {
+		t.Fatal("expected error from non-transport failure")
+	}
+	if createCount.Load() != 1 {
+		t.Errorf("create count = %d, want 1 (no reconnect)", createCount.Load())
+	}
+	// Client should still be in registry (not removed)
+	if _, ok := registry.clients[serverName]; !ok {
+		t.Error("client should remain in registry after non-transport error")
+	}
+}

--- a/internal/hierarchy/transport_error_test.go
+++ b/internal/hierarchy/transport_error_test.go
@@ -1,0 +1,128 @@
+package hierarchy
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsTransportError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		// Should detect as transport errors
+		{
+			name:     "broken pipe",
+			err:      errors.New("write: broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "EOF",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			name:     "closed network connection",
+			err:      errors.New("use of closed network connection"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "transport endpoint not connected",
+			err:      errors.New("transport endpoint is not connected"),
+			expected: true,
+		},
+		{
+			name:     "no such host",
+			err:      errors.New("dial tcp: lookup foo: no such host"),
+			expected: true,
+		},
+		// Case insensitivity
+		{
+			name:     "BROKEN PIPE uppercase",
+			err:      errors.New("BROKEN PIPE"),
+			expected: true,
+		},
+		// Should NOT detect as transport errors
+		// IMPORTANT: Timeout errors are NOT transport errors because:
+		// 1. The server may still be processing (risk of duplicate operations)
+		// 2. Retrying a slow operation won't help if server is overloaded
+		{
+			name:     "context deadline exceeded - NOT a transport error",
+			err:      errors.New("context deadline exceeded"),
+			expected: false, // Changed from true - retrying could cause duplicates!
+		},
+		{
+			name:     "i/o timeout - NOT a transport error",
+			err:      errors.New("i/o timeout"),
+			expected: false, // Changed from true - server may still be working
+		},
+		{
+			name:     "connection timed out - NOT a transport error",
+			err:      errors.New("dial tcp: connection timed out"),
+			expected: false, // Changed from true - could be temporary network issue
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "tool not found",
+			err:      errors.New("tool not found: foo.bar"),
+			expected: false,
+		},
+		{
+			name:     "invalid arguments",
+			err:      errors.New("invalid arguments: missing required field"),
+			expected: false,
+		},
+		{
+			name:     "server config not found",
+			err:      errors.New("server config not found: playwright"),
+			expected: false,
+		},
+		{
+			name:     "permission denied",
+			err:      errors.New("permission denied"),
+			expected: false,
+		},
+		{
+			name:     "file not found",
+			err:      errors.New("open /path/to/file: no such file or directory"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransportError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isTransportError(%v) = %v, want %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveClient(t *testing.T) {
+	// Create a registry with no servers (we just test the mechanics)
+	registry := NewServerRegistry(nil)
+
+	// Removing a non-existent client should not panic
+	registry.RemoveClient("nonexistent")
+
+	// The registry should still be functional
+	if registry.clients == nil {
+		t.Error("Registry clients map should not be nil after RemoveClient")
+	}
+}

--- a/internal/hierarchy/transport_error_test.go
+++ b/internal/hierarchy/transport_error_test.go
@@ -1,8 +1,17 @@
 package hierarchy
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	lazyclient "github.com/voicetreelab/lazy-mcp/internal/client"
+	"github.com/voicetreelab/lazy-mcp/internal/config"
 )
 
 func TestIsTransportError(t *testing.T) {
@@ -53,6 +62,28 @@ func TestIsTransportError(t *testing.T) {
 			err:      errors.New("BROKEN PIPE"),
 			expected: true,
 		},
+		// Wrapped errors (%w) — isTransportError uses err.Error() substring match,
+		// so wrapping preserves detectability via the error string.
+		{
+			name:     "wrapped connection reset via %w",
+			err:      fmt.Errorf("context: %w", errors.New("connection reset")),
+			expected: true,
+		},
+		{
+			name:     "wrapped broken pipe via %w",
+			err:      fmt.Errorf("call tool: %w", errors.New("write: broken pipe")),
+			expected: true,
+		},
+		{
+			name:     "double-wrapped EOF via %w",
+			err:      fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", errors.New("unexpected EOF"))),
+			expected: true,
+		},
+		{
+			name:     "mcp-go transport.Error wrapper style",
+			err:      fmt.Errorf("transport error: %v", errors.New("connection reset by peer")),
+			expected: true,
+		},
 		// Should NOT detect as transport errors
 		// IMPORTANT: Timeout errors are NOT transport errors because:
 		// 1. The server may still be processing (risk of duplicate operations)
@@ -71,6 +102,11 @@ func TestIsTransportError(t *testing.T) {
 			name:     "connection timed out - NOT a transport error",
 			err:      errors.New("dial tcp: connection timed out"),
 			expected: false, // Changed from true - could be temporary network issue
+		},
+		{
+			name:     "wrapped non-transport error via %w",
+			err:      fmt.Errorf("context: %w", errors.New("invalid arguments")),
+			expected: false,
 		},
 		{
 			name:     "nil error",
@@ -114,15 +150,99 @@ func TestIsTransportError(t *testing.T) {
 	}
 }
 
+// closeTrackingTransport is a minimal mcp-go transport that records Close().
+type closeTrackingTransport struct {
+	closed     atomic.Bool
+	closeCount atomic.Int32
+}
+
+func (t *closeTrackingTransport) Start(context.Context) error { return nil }
+func (t *closeTrackingTransport) SendRequest(context.Context, transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	return nil, errors.New("not implemented")
+}
+func (t *closeTrackingTransport) SendNotification(context.Context, mcp.JSONRPCNotification) error {
+	return nil
+}
+func (t *closeTrackingTransport) SetNotificationHandler(func(mcp.JSONRPCNotification)) {}
+func (t *closeTrackingTransport) Close() error {
+	t.closed.Store(true)
+	t.closeCount.Add(1)
+	return nil
+}
+func (t *closeTrackingTransport) GetSessionId() string { return "close-tracking" }
+
+var _ transport.Interface = (*closeTrackingTransport)(nil)
+
 func TestRemoveClient(t *testing.T) {
-	// Create a registry with no servers (we just test the mechanics)
-	registry := NewServerRegistry(nil)
-
 	// Removing a non-existent client should not panic
-	registry.RemoveClient("nonexistent")
-
-	// The registry should still be functional
-	if registry.clients == nil {
+	empty := NewServerRegistry(nil)
+	empty.RemoveClient("nonexistent")
+	if empty.clients == nil {
 		t.Error("Registry clients map should not be nil after RemoveClient")
+	}
+
+	const serverName = "mock-server"
+	tr := &closeTrackingTransport{}
+	mcpCli := mcpclient.NewClient(tr)
+	wrapped := lazyclient.NewClientFromMCP(serverName, mcpCli)
+
+	// Dummy config required so GetOrLoadServer can recreate after eviction
+	cfg := &config.MCPClientConfigV2{
+		TransportType: config.MCPClientTypeStdio,
+		Command:       "true",
+		Options:       &config.OptionsV2{},
+	}
+	registry := NewServerRegistry(map[string]*config.MCPClientConfigV2{
+		serverName: cfg,
+	})
+
+	// Seed the registry with our close-tracking client
+	registry.clients[serverName] = wrapped
+	if _, ok := registry.clients[serverName]; !ok {
+		t.Fatal("client should be present in registry before RemoveClient")
+	}
+
+	var createCount atomic.Int32
+	var freshClient *lazyclient.Client
+	registry.createClient = func(name string, conf *config.MCPClientConfigV2) (*lazyclient.Client, error) {
+		createCount.Add(1)
+		// Fresh transport that can answer Initialize (GetOrLoadServer always inits)
+		initTr := newReconnectMockTransport(errors.New("broken pipe"), 0)
+		initMcp := mcpclient.NewClient(initTr)
+		freshClient = lazyclient.NewClientFromMCP(name, initMcp)
+		return freshClient, nil
+	}
+
+	registry.RemoveClient(serverName)
+
+	// (a) client removed from registry
+	if _, ok := registry.clients[serverName]; ok {
+		t.Error("client should be removed from registry after RemoveClient")
+	}
+	// (b) Close() called on the removed client
+	if !tr.closed.Load() {
+		t.Error("Close() should have been called on the removed client")
+	}
+	if got := tr.closeCount.Load(); got != 1 {
+		t.Errorf("Close() call count = %d, want 1", got)
+	}
+
+	// (c) subsequent lookup creates a FRESH client
+	ctx := context.Background()
+	got, err := registry.GetOrLoadServer(ctx, serverName)
+	if err != nil {
+		t.Fatalf("GetOrLoadServer after RemoveClient: %v", err)
+	}
+	if createCount.Load() != 1 {
+		t.Errorf("createClient call count = %d, want 1", createCount.Load())
+	}
+	if got == wrapped {
+		t.Error("GetOrLoadServer should return a fresh client, not the removed instance")
+	}
+	if got != freshClient {
+		t.Error("GetOrLoadServer should return the client created by the factory")
+	}
+	if registry.clients[serverName] != got {
+		t.Error("fresh client should be stored in the registry")
 	}
 }

--- a/internal/metrics/doctor.go
+++ b/internal/metrics/doctor.go
@@ -1,0 +1,327 @@
+package metrics
+
+import (
+	"fmt"
+	"time"
+)
+
+// CheckStatus represents the result status of a health check
+type CheckStatus string
+
+const (
+	CheckStatusPass    CheckStatus = "pass"
+	CheckStatusWarning CheckStatus = "warning"
+	CheckStatusFail    CheckStatus = "fail"
+)
+
+// Check represents a single health check result
+type Check struct {
+	Name       string                 `json:"name"`
+	Status     CheckStatus            `json:"status"`
+	Message    string                 `json:"message"`
+	Details    map[string]interface{} `json:"details,omitempty"`
+	Suggestion string                 `json:"suggestion,omitempty"`
+}
+
+// DoctorResult is the response from proxy_doctor
+type DoctorResult struct {
+	Status      CheckStatus `json:"status"`
+	Checks      []Check     `json:"checks"`
+	Suggestions []string    `json:"suggestions"`
+}
+
+// Thresholds for health checks
+const (
+	LatencyWarningThreshold  = 30 * time.Second
+	LatencyCriticalThreshold = 45 * time.Second
+	ErrorRateWarningThreshold  = 5.0  // percent
+	ErrorRateCriticalThreshold = 10.0 // percent
+	TimeoutCountThreshold    = 2
+)
+
+// RunDoctor runs all health checks and returns diagnostics
+func RunDoctor(store *Store, expectedServers []string) *DoctorResult {
+	result := &DoctorResult{
+		Status:      CheckStatusPass,
+		Checks:      make([]Check, 0),
+		Suggestions: make([]string, 0),
+	}
+
+	// Run all checks
+	checks := []func(*Store, []string) Check{
+		checkServerConnectivity,
+		checkLatency,
+		checkTimeouts,
+		checkErrorRate,
+		checkMemory,
+	}
+
+	for _, check := range checks {
+		c := check(store, expectedServers)
+		result.Checks = append(result.Checks, c)
+
+		// Update overall status (fail > warning > pass)
+		if c.Status == CheckStatusFail && result.Status != CheckStatusFail {
+			result.Status = CheckStatusFail
+		} else if c.Status == CheckStatusWarning && result.Status == CheckStatusPass {
+			result.Status = CheckStatusWarning
+		}
+
+		// Collect suggestions
+		if c.Suggestion != "" {
+			result.Suggestions = append(result.Suggestions, c.Suggestion)
+		}
+	}
+
+	return result
+}
+
+// checkServerConnectivity verifies all expected servers are connected
+func checkServerConnectivity(store *Store, expectedServers []string) Check {
+	activeServers := store.GetActiveServers()
+	activeMap := make(map[string]bool)
+	for _, s := range activeServers {
+		activeMap[s] = true
+	}
+
+	var disconnected []string
+	for _, expected := range expectedServers {
+		if !activeMap[expected] {
+			disconnected = append(disconnected, expected)
+		}
+	}
+
+	if len(disconnected) > 0 {
+		return Check{
+			Name:    "server_connectivity",
+			Status:  CheckStatusWarning,
+			Message: fmt.Sprintf("%d of %d servers not yet loaded: %v", len(disconnected), len(expectedServers), disconnected),
+			Details: map[string]interface{}{
+				"active":       activeServers,
+				"disconnected": disconnected,
+			},
+			Suggestion: "Disconnected servers will load on first tool call (lazy loading is enabled)",
+		}
+	}
+
+	return Check{
+		Name:    "server_connectivity",
+		Status:  CheckStatusPass,
+		Message: fmt.Sprintf("All %d servers responding", len(activeServers)),
+	}
+}
+
+// checkLatency checks for high latency servers
+func checkLatency(store *Store, _ []string) Check {
+	calls := store.GetCallsInWindow("", time.Hour)
+	if len(calls) == 0 {
+		return Check{
+			Name:    "latency",
+			Status:  CheckStatusPass,
+			Message: "No calls in the last hour to measure",
+		}
+	}
+
+	// Group by server and find p99
+	serverCalls := make(map[string][]time.Duration)
+	for _, call := range calls {
+		serverCalls[call.Server] = append(serverCalls[call.Server], call.Duration)
+	}
+
+	var warnings []string
+	var details []map[string]interface{}
+
+	for server, durations := range serverCalls {
+		p99 := percentile(durations, 0.99)
+		if p99 >= LatencyCriticalThreshold {
+			warnings = append(warnings, fmt.Sprintf("%s p99=%.1fs (critical)", server, p99.Seconds()))
+			details = append(details, map[string]interface{}{
+				"server":    server,
+				"p99":       fmt.Sprintf("%.1fs", p99.Seconds()),
+				"threshold": fmt.Sprintf("%.0fs", LatencyCriticalThreshold.Seconds()), // Show critical threshold
+			})
+		} else if p99 >= LatencyWarningThreshold {
+			warnings = append(warnings, fmt.Sprintf("%s p99=%.1fs", server, p99.Seconds()))
+			details = append(details, map[string]interface{}{
+				"server":    server,
+				"p99":       fmt.Sprintf("%.1fs", p99.Seconds()),
+				"threshold": fmt.Sprintf("%.0fs", LatencyWarningThreshold.Seconds()),
+			})
+		}
+	}
+
+	if len(warnings) > 0 {
+		status := CheckStatusWarning
+		for _, d := range details {
+			p99Str := d["p99"].(string)
+			// Check if any are critical
+			var p99Val float64
+			fmt.Sscanf(p99Str, "%fs", &p99Val)
+			if p99Val >= LatencyCriticalThreshold.Seconds() {
+				status = CheckStatusFail
+				break
+			}
+		}
+
+		return Check{
+			Name:    "latency",
+			Status:  status,
+			Message: fmt.Sprintf("High latency detected: %v", warnings),
+			Details: map[string]interface{}{
+				"servers": details,
+			},
+			Suggestion: "Consider using smaller query parameters or increasing timeout for affected servers",
+		}
+	}
+
+	return Check{
+		Name:    "latency",
+		Status:  CheckStatusPass,
+		Message: "All servers within latency thresholds",
+	}
+}
+
+// checkTimeouts checks for recent timeout events
+func checkTimeouts(store *Store, _ []string) Check {
+	calls := store.GetCallsInWindow("", time.Hour)
+
+	// Count timeouts by server
+	timeoutsByServer := make(map[string]int)
+	toolsByServer := make(map[string][]string)
+	for _, call := range calls {
+		if call.IsTimeout {
+			timeoutsByServer[call.Server]++
+			toolsByServer[call.Server] = append(toolsByServer[call.Server], call.ToolPath)
+		}
+	}
+
+	if len(timeoutsByServer) == 0 {
+		return Check{
+			Name:    "timeouts",
+			Status:  CheckStatusPass,
+			Message: "No timeouts in the last hour",
+		}
+	}
+
+	var messages []string
+	var suggestions []string
+	totalTimeouts := 0
+
+	for server, count := range timeoutsByServer {
+		totalTimeouts += count
+		messages = append(messages, fmt.Sprintf("%s: %d timeout(s)", server, count))
+
+		// Generate specific suggestions based on server
+		if len(toolsByServer[server]) > 0 {
+			suggestions = append(suggestions, fmt.Sprintf("%s: Consider using smaller parameters for %v", server, unique(toolsByServer[server])))
+		}
+	}
+
+	status := CheckStatusWarning
+	if totalTimeouts >= TimeoutCountThreshold*2 {
+		status = CheckStatusFail
+	}
+
+	return Check{
+		Name:    "timeouts",
+		Status:  status,
+		Message: fmt.Sprintf("%d timeout(s) in last hour: %v", totalTimeouts, messages),
+		Details: map[string]interface{}{
+			"by_server":      timeoutsByServer,
+			"affected_tools": toolsByServer,
+		},
+		Suggestion: joinStrings(suggestions, "; "),
+	}
+}
+
+// checkErrorRate checks the overall error rate
+func checkErrorRate(store *Store, _ []string) Check {
+	calls := store.GetCallsInWindow("", time.Hour)
+	if len(calls) == 0 {
+		return Check{
+			Name:    "error_rate",
+			Status:  CheckStatusPass,
+			Message: "No calls in the last hour to measure",
+		}
+	}
+
+	errorCount := 0
+	for _, call := range calls {
+		if !call.Success {
+			errorCount++
+		}
+	}
+
+	errorRate := float64(errorCount) / float64(len(calls)) * 100
+
+	if errorRate >= ErrorRateCriticalThreshold {
+		return Check{
+			Name:    "error_rate",
+			Status:  CheckStatusFail,
+			Message: fmt.Sprintf("Error rate %.1f%% exceeds critical threshold (%.0f%%)", errorRate, ErrorRateCriticalThreshold),
+			Details: map[string]interface{}{
+				"error_count": errorCount,
+				"total_calls": len(calls),
+				"error_rate":  fmt.Sprintf("%.1f%%", errorRate),
+			},
+			Suggestion: "Check recent_errors in get_proxy_metrics for details on failing tools",
+		}
+	}
+
+	if errorRate >= ErrorRateWarningThreshold {
+		return Check{
+			Name:    "error_rate",
+			Status:  CheckStatusWarning,
+			Message: fmt.Sprintf("Error rate %.1f%% exceeds warning threshold (%.0f%%)", errorRate, ErrorRateWarningThreshold),
+			Details: map[string]interface{}{
+				"error_count": errorCount,
+				"total_calls": len(calls),
+				"error_rate":  fmt.Sprintf("%.1f%%", errorRate),
+			},
+		}
+	}
+
+	return Check{
+		Name:    "error_rate",
+		Status:  CheckStatusPass,
+		Message: fmt.Sprintf("Error rate %.1f%% (threshold: %.0f%%)", errorRate, ErrorRateWarningThreshold),
+	}
+}
+
+// checkMemory reports metrics store memory usage (placeholder - always passes)
+func checkMemory(store *Store, _ []string) Check {
+	calls := store.GetCallsInWindow("", 24*time.Hour)
+	// Rough estimate: ~200 bytes per call
+	estimatedMB := float64(len(calls)*200) / 1024 / 1024
+
+	return Check{
+		Name:    "memory",
+		Status:  CheckStatusPass,
+		Message: fmt.Sprintf("Metrics store using ~%.1fMB (%d records)", estimatedMB, len(calls)),
+	}
+}
+
+// Helper functions
+
+func unique(items []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, item := range items {
+		if !seen[item] {
+			seen[item] = true
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func joinStrings(items []string, sep string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	result := items[0]
+	for i := 1; i < len(items); i++ {
+		result += sep + items[i]
+	}
+	return result
+}

--- a/internal/metrics/doctor_test.go
+++ b/internal/metrics/doctor_test.go
@@ -1,0 +1,411 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCheckServerConnectivity verifies server connectivity health check
+func TestCheckServerConnectivity(t *testing.T) {
+	tests := []struct {
+		name            string
+		loadServers     []string // Servers to load (will be marked connected)
+		expectedServers []string // Servers the check expects to see
+		expectedStatus  CheckStatus
+	}{
+		{
+			name:            "all servers connected",
+			loadServers:     []string{"gmail", "asana"},
+			expectedServers: []string{"gmail", "asana"},
+			expectedStatus:  CheckStatusPass,
+		},
+		{
+			name:            "some servers disconnected",
+			loadServers:     []string{"gmail"},
+			expectedServers: []string{"gmail", "asana"},
+			expectedStatus:  CheckStatusWarning,
+		},
+		{
+			name:            "no servers connected",
+			loadServers:     []string{},
+			expectedServers: []string{"gmail", "asana"},
+			expectedStatus:  CheckStatusWarning,
+		},
+		{
+			name:            "no servers expected",
+			loadServers:     []string{},
+			expectedServers: []string{},
+			expectedStatus:  CheckStatusPass,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(time.Hour, "")
+			defer store.Stop()
+
+			// Load servers
+			for _, s := range tt.loadServers {
+				store.RecordServerLoad(s, 100)
+			}
+
+			result := checkServerConnectivity(store, tt.expectedServers)
+			assert.Equal(t, tt.expectedStatus, result.Status)
+			assert.Equal(t, "server_connectivity", result.Name)
+		})
+	}
+}
+
+// TestCheckLatency verifies latency health check thresholds
+func TestCheckLatency(t *testing.T) {
+	tests := []struct {
+		name           string
+		calls          []struct {
+			server   string
+			duration time.Duration
+		}
+		expectedStatus CheckStatus
+	}{
+		{
+			name:           "no calls - pass",
+			calls:          []struct{ server string; duration time.Duration }{},
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name: "all fast - pass",
+			calls: []struct{ server string; duration time.Duration }{
+				{"fast", 100 * time.Millisecond},
+				{"fast", 200 * time.Millisecond},
+			},
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name: "warning threshold exceeded",
+			calls: []struct{ server string; duration time.Duration }{
+				{"slow", 35 * time.Second}, // Above 30s warning threshold
+			},
+			expectedStatus: CheckStatusWarning,
+		},
+		{
+			name: "critical threshold exceeded",
+			calls: []struct{ server string; duration time.Duration }{
+				{"critical", 50 * time.Second}, // Above 45s critical threshold
+			},
+			expectedStatus: CheckStatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(time.Hour, "")
+			defer store.Stop()
+
+			for _, call := range tt.calls {
+				store.RecordCall(call.server, "tool", call.duration, nil)
+			}
+
+			result := checkLatency(store, nil)
+			assert.Equal(t, tt.expectedStatus, result.Status)
+			assert.Equal(t, "latency", result.Name)
+		})
+	}
+}
+
+// TestCheckTimeouts verifies timeout detection health check
+func TestCheckTimeouts(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(*Store)
+		expectedStatus CheckStatus
+	}{
+		{
+			name:           "no calls - pass",
+			setupFunc:      func(s *Store) {},
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name: "no timeouts - pass",
+			setupFunc: func(s *Store) {
+				s.RecordCall("server", "tool", 100*time.Millisecond, nil)
+				s.RecordCall("server", "tool", 200*time.Millisecond, errors.New("regular error"))
+			},
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name: "single timeout - warning",
+			setupFunc: func(s *Store) {
+				s.RecordCall("server", "tool", 100*time.Millisecond, nil)
+				s.RecordCall("server", "tool", 30*time.Second, errors.New("context deadline exceeded"))
+			},
+			expectedStatus: CheckStatusWarning,
+		},
+		{
+			name: "many timeouts - fail",
+			setupFunc: func(s *Store) {
+				for i := 0; i < 5; i++ {
+					s.RecordCall("server", "tool", 30*time.Second, errors.New("timeout"))
+				}
+			},
+			expectedStatus: CheckStatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(time.Hour, "")
+			defer store.Stop()
+
+			tt.setupFunc(store)
+
+			result := checkTimeouts(store, nil)
+			assert.Equal(t, tt.expectedStatus, result.Status)
+			assert.Equal(t, "timeouts", result.Name)
+		})
+	}
+}
+
+// TestCheckErrorRate verifies error rate health check thresholds
+func TestCheckErrorRate(t *testing.T) {
+	tests := []struct {
+		name           string
+		successCount   int
+		errorCount     int
+		expectedStatus CheckStatus
+	}{
+		{
+			name:           "no calls - pass",
+			successCount:   0,
+			errorCount:     0,
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name:           "100% success - pass",
+			successCount:   100,
+			errorCount:     0,
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name:           "4% error rate - pass",
+			successCount:   96,
+			errorCount:     4,
+			expectedStatus: CheckStatusPass,
+		},
+		{
+			name:           "6% error rate - warning",
+			successCount:   94,
+			errorCount:     6,
+			expectedStatus: CheckStatusWarning,
+		},
+		{
+			name:           "11% error rate - fail",
+			successCount:   89,
+			errorCount:     11,
+			expectedStatus: CheckStatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(time.Hour, "")
+			defer store.Stop()
+
+			for i := 0; i < tt.successCount; i++ {
+				store.RecordCall("server", "tool", 100*time.Millisecond, nil)
+			}
+			for i := 0; i < tt.errorCount; i++ {
+				store.RecordCall("server", "tool", 100*time.Millisecond, errors.New("error"))
+			}
+
+			result := checkErrorRate(store, nil)
+			assert.Equal(t, tt.expectedStatus, result.Status)
+			assert.Equal(t, "error_rate", result.Name)
+		})
+	}
+}
+
+// TestCheckMemory verifies memory usage reporting
+func TestCheckMemory(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	// Add some calls
+	for i := 0; i < 100; i++ {
+		store.RecordCall("server", "tool", 100*time.Millisecond, nil)
+	}
+
+	result := checkMemory(store, nil)
+
+	// Memory check should always pass (informational only)
+	assert.Equal(t, CheckStatusPass, result.Status)
+	assert.Equal(t, "memory", result.Name)
+	assert.Contains(t, result.Message, "100 records")
+}
+
+// TestRunDoctor verifies full doctor diagnostics
+func TestRunDoctor(t *testing.T) {
+	t.Run("healthy state", func(t *testing.T) {
+		store := NewStore(time.Hour, "")
+		defer store.Stop()
+
+		store.RecordServerLoad("server1", 100)
+		store.RecordCall("server1", "tool", 100*time.Millisecond, nil)
+
+		result := RunDoctor(store, []string{"server1"})
+
+		assert.Equal(t, CheckStatusPass, result.Status)
+		assert.Len(t, result.Checks, 5, "Should run all 5 checks")
+	})
+
+	t.Run("unhealthy state aggregates worst status", func(t *testing.T) {
+		store := NewStore(time.Hour, "")
+		defer store.Stop()
+
+		// Add critical latency
+		store.RecordCall("slow", "tool", 50*time.Second, nil)
+
+		result := RunDoctor(store, []string{"server1"})
+
+		assert.Equal(t, CheckStatusFail, result.Status, "Overall status should be worst individual status")
+	})
+
+	t.Run("suggestions are collected", func(t *testing.T) {
+		store := NewStore(time.Hour, "")
+		defer store.Stop()
+
+		// Create conditions that generate suggestions
+		store.RecordCall("server", "tool", 30*time.Second, errors.New("context deadline exceeded"))
+
+		result := RunDoctor(store, []string{"missing-server"})
+
+		assert.NotEmpty(t, result.Suggestions, "Should have suggestions for issues found")
+	})
+}
+
+// TestCheckStatusPriority verifies status aggregation priority
+func TestCheckStatusPriority(t *testing.T) {
+	// Verify fail > warning > pass priority
+	tests := []struct {
+		name           string
+		checkStatuses  []CheckStatus
+		expectedOverall CheckStatus
+	}{
+		{
+			name:           "all pass",
+			checkStatuses:  []CheckStatus{CheckStatusPass, CheckStatusPass, CheckStatusPass},
+			expectedOverall: CheckStatusPass,
+		},
+		{
+			name:           "one warning among passes",
+			checkStatuses:  []CheckStatus{CheckStatusPass, CheckStatusWarning, CheckStatusPass},
+			expectedOverall: CheckStatusWarning,
+		},
+		{
+			name:           "one fail overrides warnings",
+			checkStatuses:  []CheckStatus{CheckStatusWarning, CheckStatusFail, CheckStatusWarning},
+			expectedOverall: CheckStatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the status aggregation logic from RunDoctor
+			overall := CheckStatusPass
+			for _, status := range tt.checkStatuses {
+				if status == CheckStatusFail && overall != CheckStatusFail {
+					overall = CheckStatusFail
+				} else if status == CheckStatusWarning && overall == CheckStatusPass {
+					overall = CheckStatusWarning
+				}
+			}
+			assert.Equal(t, tt.expectedOverall, overall)
+		})
+	}
+}
+
+// TestUniqueHelper verifies the unique helper function
+func TestUniqueHelper(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "no duplicates",
+			input:    []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "with duplicates",
+			input:    []string{"a", "b", "a", "c", "b"},
+			expected: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := unique(tt.input)
+			assert.Len(t, result, len(tt.expected))
+			for _, expected := range tt.expected {
+				assert.Contains(t, result, expected)
+			}
+		})
+	}
+}
+
+// TestJoinStringsHelper verifies the joinStrings helper function
+func TestJoinStringsHelper(t *testing.T) {
+	tests := []struct {
+		name     string
+		items    []string
+		sep      string
+		expected string
+	}{
+		{
+			name:     "empty slice",
+			items:    []string{},
+			sep:      "; ",
+			expected: "",
+		},
+		{
+			name:     "single item",
+			items:    []string{"one"},
+			sep:      "; ",
+			expected: "one",
+		},
+		{
+			name:     "multiple items",
+			items:    []string{"one", "two", "three"},
+			sep:      "; ",
+			expected: "one; two; three",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := joinStrings(tt.items, tt.sep)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestThresholdConstants verifies threshold values are reasonable
+func TestThresholdConstants(t *testing.T) {
+	// Warning should be less than critical
+	assert.Less(t, LatencyWarningThreshold, LatencyCriticalThreshold)
+	assert.Less(t, ErrorRateWarningThreshold, ErrorRateCriticalThreshold)
+
+	// Thresholds should be positive
+	assert.Greater(t, LatencyWarningThreshold, time.Duration(0))
+	assert.Greater(t, LatencyCriticalThreshold, time.Duration(0))
+	assert.Greater(t, ErrorRateWarningThreshold, float64(0))
+	assert.Greater(t, ErrorRateCriticalThreshold, float64(0))
+	assert.Greater(t, TimeoutCountThreshold, 0)
+}

--- a/internal/metrics/store.go
+++ b/internal/metrics/store.go
@@ -1,0 +1,464 @@
+// Package metrics provides observability for the MCP proxy.
+// It tracks tool call latencies, success/failure rates, and server health.
+// Metrics are stored in-memory with optional JSON persistence.
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ToolCall represents a single tool invocation with timing and status
+type ToolCall struct {
+	Timestamp time.Time     `json:"ts"`
+	Server    string        `json:"server"`
+	ToolPath  string        `json:"tool_path"`
+	Duration  time.Duration `json:"duration_ms"`
+	Success   bool          `json:"success"`
+	Error     string        `json:"error,omitempty"`
+	IsTimeout bool          `json:"is_timeout,omitempty"`
+}
+
+// MarshalJSON custom marshaler to output duration in milliseconds
+func (tc ToolCall) MarshalJSON() ([]byte, error) {
+	type Alias ToolCall
+	return json.Marshal(&struct {
+		Alias
+		Duration int64 `json:"duration_ms"`
+	}{
+		Alias:    Alias(tc),
+		Duration: tc.Duration.Milliseconds(),
+	})
+}
+
+// UnmarshalJSON custom unmarshaler to convert milliseconds back to time.Duration
+// IMPORTANT: Without this, loading from persistence would fail because Go's
+// json.Unmarshal cannot automatically convert int64 to time.Duration
+func (tc *ToolCall) UnmarshalJSON(data []byte) error {
+	type Alias ToolCall
+	aux := &struct {
+		*Alias
+		Duration int64 `json:"duration_ms"`
+	}{
+		Alias: (*Alias)(tc),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	tc.Duration = time.Duration(aux.Duration) * time.Millisecond
+	return nil
+}
+
+// ServerStats tracks server-level statistics
+type ServerStats struct {
+	Name        string    `json:"name"`
+	LoadedAt    time.Time `json:"loaded_at"`
+	ColdStartMs int64     `json:"cold_start_ms"`
+	IsConnected bool      `json:"is_connected"`
+}
+
+// Store is the in-memory metrics store with optional JSON persistence
+type Store struct {
+	mu          sync.RWMutex
+	calls       []ToolCall
+	servers     map[string]*ServerStats
+	retention   time.Duration
+	persistPath string
+	stopCh      chan struct{}
+}
+
+// NewStore creates a new metrics store
+func NewStore(retention time.Duration, persistPath string) *Store {
+	s := &Store{
+		calls:       make([]ToolCall, 0),
+		servers:     make(map[string]*ServerStats),
+		retention:   retention,
+		persistPath: persistPath,
+		stopCh:      make(chan struct{}),
+	}
+	if persistPath != "" {
+		s.loadFromFile()
+	}
+	go s.pruneLoop()
+	return s
+}
+
+// RecordCall records a tool call with timing and result
+func (s *Store) RecordCall(server, toolPath string, duration time.Duration, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	call := ToolCall{
+		Timestamp: time.Now(),
+		Server:    server,
+		ToolPath:  toolPath,
+		Duration:  duration,
+		Success:   err == nil,
+	}
+	if err != nil {
+		call.Error = err.Error()
+		call.IsTimeout = isTimeoutError(err)
+	}
+	s.calls = append(s.calls, call)
+}
+
+// RecordServerLoad records a server cold-start event
+func (s *Store) RecordServerLoad(name string, coldStartMs int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.servers[name] = &ServerStats{
+		Name:        name,
+		LoadedAt:    time.Now(),
+		ColdStartMs: coldStartMs,
+		IsConnected: true,
+	}
+}
+
+// RecordServerDisconnect records a server disconnection
+func (s *Store) RecordServerDisconnect(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if stats, exists := s.servers[name]; exists {
+		stats.IsConnected = false
+	}
+}
+
+// GetMetrics returns metrics for the specified time window and optional server filter
+func (s *Store) GetMetrics(serverFilter string, since time.Duration) map[string]interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cutoff := time.Now().Add(-since)
+	result := make(map[string]interface{})
+
+	// Filter calls by time window
+	var filteredCalls []ToolCall
+	for _, call := range s.calls {
+		if call.Timestamp.After(cutoff) {
+			if serverFilter == "" || call.Server == serverFilter {
+				filteredCalls = append(filteredCalls, call)
+			}
+		}
+	}
+
+	// Compute summary
+	totalCalls := len(filteredCalls)
+	successCount := 0
+	timeoutCount := 0
+	for _, call := range filteredCalls {
+		if call.Success {
+			successCount++
+		}
+		if call.IsTimeout {
+			timeoutCount++
+		}
+	}
+
+	successRate := "0%"
+	if totalCalls > 0 {
+		rate := float64(successCount) / float64(totalCalls) * 100
+		successRate = fmt.Sprintf("%.1f%%", rate)
+	}
+
+	// Count active servers
+	activeServers := 0
+	for _, stats := range s.servers {
+		if stats.IsConnected {
+			activeServers++
+		}
+	}
+
+	result["time_window"] = formatDuration(since)
+	result["summary"] = map[string]interface{}{
+		"total_calls":    totalCalls,
+		"success_rate":   successRate,
+		"timeout_count":  timeoutCount,
+		"active_servers": activeServers,
+	}
+
+	// Group by server
+	byServer := make(map[string]map[string]interface{})
+	serverCalls := make(map[string][]ToolCall)
+	for _, call := range filteredCalls {
+		serverCalls[call.Server] = append(serverCalls[call.Server], call)
+	}
+
+	for server, calls := range serverCalls {
+		serverMetrics := computeServerMetrics(calls)
+		byServer[server] = serverMetrics
+	}
+	result["by_server"] = byServer
+
+	// Recent errors (last 10)
+	var recentErrors []map[string]interface{}
+	for i := len(filteredCalls) - 1; i >= 0 && len(recentErrors) < 10; i-- {
+		call := filteredCalls[i]
+		if !call.Success {
+			recentErrors = append(recentErrors, map[string]interface{}{
+				"time":   call.Timestamp.Format(time.RFC3339),
+				"server": call.Server,
+				"tool":   call.ToolPath,
+				"error":  call.Error,
+			})
+		}
+	}
+	result["recent_errors"] = recentErrors
+
+	return result
+}
+
+// GetActiveServers returns list of currently connected servers
+func (s *Store) GetActiveServers() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var active []string
+	for name, stats := range s.servers {
+		if stats.IsConnected {
+			active = append(active, name)
+		}
+	}
+	return active
+}
+
+// GetServerStats returns stats for a specific server
+func (s *Store) GetServerStats(name string) *ServerStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if stats, exists := s.servers[name]; exists {
+		statsCopy := *stats
+		return &statsCopy
+	}
+	return nil
+}
+
+// GetCallsInWindow returns all calls in the time window for a server
+func (s *Store) GetCallsInWindow(server string, since time.Duration) []ToolCall {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cutoff := time.Now().Add(-since)
+	var result []ToolCall
+	for _, call := range s.calls {
+		if call.Timestamp.After(cutoff) && (server == "" || call.Server == server) {
+			result = append(result, call)
+		}
+	}
+	return result
+}
+
+// Stop stops the background prune goroutine
+func (s *Store) Stop() {
+	close(s.stopCh)
+}
+
+// pruneLoop periodically removes old entries
+func (s *Store) pruneLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.prune()
+			if s.persistPath != "" {
+				s.saveToFile()
+			}
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+// prune removes entries older than retention period
+func (s *Store) prune() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().Add(-s.retention)
+	var kept []ToolCall
+	for _, call := range s.calls {
+		if call.Timestamp.After(cutoff) {
+			kept = append(kept, call)
+		}
+	}
+	s.calls = kept
+}
+
+// loadFromFile loads metrics from the persistence file
+func (s *Store) loadFromFile() {
+	data, err := os.ReadFile(s.persistPath)
+	if err != nil {
+		return // File doesn't exist or can't be read
+	}
+
+	var saved struct {
+		Calls   []ToolCall              `json:"calls"`
+		Servers map[string]*ServerStats `json:"servers"`
+	}
+	if err := json.Unmarshal(data, &saved); err != nil {
+		return
+	}
+
+	s.calls = saved.Calls
+	s.servers = saved.Servers
+
+	// Mark all servers as disconnected on load (they need to reconnect)
+	for _, stats := range s.servers {
+		stats.IsConnected = false
+	}
+}
+
+// saveToFile persists metrics to the file
+func (s *Store) saveToFile() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	saved := struct {
+		Calls   []ToolCall              `json:"calls"`
+		Servers map[string]*ServerStats `json:"servers"`
+	}{
+		Calls:   s.calls,
+		Servers: s.servers,
+	}
+
+	data, err := json.MarshalIndent(saved, "", "  ")
+	if err != nil {
+		log.Printf("Warning: failed to marshal metrics for persistence: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(s.persistPath, data, 0644); err != nil {
+		log.Printf("Warning: failed to persist metrics to %s: %v", s.persistPath, err)
+	}
+}
+
+// Helper functions
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "context deadline exceeded") ||
+		strings.Contains(errStr, "timeout") ||
+		strings.Contains(errStr, "timed out")
+}
+
+func computeServerMetrics(calls []ToolCall) map[string]interface{} {
+	successCount := 0
+	timeoutCount := 0
+	var durations []time.Duration
+	var lastError string
+	slowestTool := ""
+	var slowestDuration time.Duration
+
+	for _, call := range calls {
+		if call.Success {
+			successCount++
+		}
+		if call.IsTimeout {
+			timeoutCount++
+		}
+		if !call.Success && call.Error != "" {
+			lastError = call.Error
+		}
+		durations = append(durations, call.Duration)
+		if call.Duration > slowestDuration {
+			slowestDuration = call.Duration
+			slowestTool = call.ToolPath
+		}
+	}
+
+	result := map[string]interface{}{
+		"calls":    len(calls),
+		"success":  successCount,
+		"timeouts": timeoutCount,
+	}
+
+	if len(durations) > 0 {
+		result["latency"] = map[string]string{
+			"p50": formatDuration(percentile(durations, 0.50)),
+			"p95": formatDuration(percentile(durations, 0.95)),
+			"p99": formatDuration(percentile(durations, 0.99)),
+		}
+	}
+
+	if slowestTool != "" {
+		result["slowest_tool"] = slowestTool
+	}
+	if lastError != "" {
+		result["last_error"] = lastError
+	}
+
+	return result
+}
+
+func percentile(durations []time.Duration, p float64) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(durations))
+	copy(sorted, durations)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+	index := int(float64(len(sorted)-1) * p)
+	return sorted[index]
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}
+
+// Singleton for global metrics store
+var (
+	globalStore *Store
+	globalOnce  sync.Once
+)
+
+// InitGlobalStore initializes the global metrics store
+func InitGlobalStore(retention time.Duration, persistPath string) *Store {
+	globalOnce.Do(func() {
+		globalStore = NewStore(retention, persistPath)
+	})
+	return globalStore
+}
+
+// GetGlobalStore returns the global metrics store (or nil if not initialized)
+func GetGlobalStore() *Store {
+	return globalStore
+}
+
+// ParseDuration parses a duration string like "1h", "24h", "7d"
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Hour, nil // default
+	}
+
+	// Handle days specially
+	if strings.HasSuffix(s, "d") {
+		daysStr := strings.TrimSuffix(s, "d")
+		days, err := strconv.Atoi(daysStr)
+		if err != nil {
+			return 0, fmt.Errorf("invalid day duration: %s", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+
+	return time.ParseDuration(s)
+}

--- a/internal/metrics/store_test.go
+++ b/internal/metrics/store_test.go
@@ -1,0 +1,481 @@
+package metrics
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolCallMarshalJSON verifies JSON serialization outputs duration in milliseconds
+func TestToolCallMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		call     ToolCall
+		contains string
+	}{
+		{
+			name:     "zero duration",
+			call:     ToolCall{Duration: 0},
+			contains: `"duration_ms":0`,
+		},
+		{
+			name:     "1500ms duration",
+			call:     ToolCall{Duration: 1500 * time.Millisecond},
+			contains: `"duration_ms":1500`,
+		},
+		{
+			name:     "with error field",
+			call:     ToolCall{Duration: 500 * time.Millisecond, Error: "test error"},
+			contains: `"duration_ms":500`,
+		},
+		{
+			name:     "60 second duration",
+			call:     ToolCall{Duration: 60 * time.Second},
+			contains: `"duration_ms":60000`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.call)
+			require.NoError(t, err)
+			assert.Contains(t, string(data), tt.contains)
+		})
+	}
+}
+
+// TestToolCallUnmarshalJSON verifies JSON deserialization converts milliseconds back to Duration
+// This test was added after PR review identified missing UnmarshalJSON as a bug
+func TestToolCallUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected time.Duration
+	}{
+		{
+			name:     "zero duration",
+			json:     `{"ts":"2024-01-01T00:00:00Z","server":"test","tool_path":"test.tool","duration_ms":0,"success":true}`,
+			expected: 0,
+		},
+		{
+			name:     "1500ms",
+			json:     `{"ts":"2024-01-01T00:00:00Z","server":"test","tool_path":"test.tool","duration_ms":1500,"success":true}`,
+			expected: 1500 * time.Millisecond,
+		},
+		{
+			name:     "60 seconds (60000ms)",
+			json:     `{"ts":"2024-01-01T00:00:00Z","server":"test","tool_path":"test.tool","duration_ms":60000,"success":true}`,
+			expected: 60 * time.Second,
+		},
+		{
+			name:     "with error",
+			json:     `{"ts":"2024-01-01T00:00:00Z","server":"test","tool_path":"test.tool","duration_ms":500,"success":false,"error":"timeout"}`,
+			expected: 500 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var call ToolCall
+			err := json.Unmarshal([]byte(tt.json), &call)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, call.Duration, "Duration should be correctly parsed from milliseconds")
+		})
+	}
+}
+
+// TestSerializationRoundTrip verifies that marshal→unmarshal preserves all data
+// Critical test: ensures persistence loading doesn't corrupt duration values
+func TestSerializationRoundTrip(t *testing.T) {
+	original := ToolCall{
+		Timestamp: time.Now().Truncate(time.Second), // Truncate to avoid nanosecond precision issues
+		Server:    "test-server",
+		ToolPath:  "gmail.send_email",
+		Duration:  1500 * time.Millisecond,
+		Success:   true,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// Unmarshal back
+	var restored ToolCall
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	// Verify all fields survive round-trip
+	assert.Equal(t, original.Duration, restored.Duration, "Duration must survive round-trip")
+	assert.Equal(t, original.Server, restored.Server)
+	assert.Equal(t, original.ToolPath, restored.ToolPath)
+	assert.Equal(t, original.Success, restored.Success)
+}
+
+// TestSerializationRoundTripWithError verifies error fields are preserved
+func TestSerializationRoundTripWithError(t *testing.T) {
+	original := ToolCall{
+		Timestamp: time.Now().Truncate(time.Second),
+		Server:    "gmail",
+		ToolPath:  "gmail.send_email",
+		Duration:  30 * time.Second,
+		Success:   false,
+		Error:     "context deadline exceeded",
+		IsTimeout: true,
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored ToolCall
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Error, restored.Error)
+	assert.Equal(t, original.IsTimeout, restored.IsTimeout)
+	assert.Equal(t, original.Duration, restored.Duration)
+}
+
+// TestPercentile verifies percentile calculation accuracy
+func TestPercentile(t *testing.T) {
+	tests := []struct {
+		name      string
+		durations []time.Duration
+		p         float64
+		expected  time.Duration
+	}{
+		{
+			name:      "empty slice returns zero",
+			durations: []time.Duration{},
+			p:         0.50,
+			expected:  0,
+		},
+		{
+			name:      "single value returns that value",
+			durations: []time.Duration{100 * time.Millisecond},
+			p:         0.50,
+			expected:  100 * time.Millisecond,
+		},
+		{
+			name:      "p50 of sorted sequence",
+			durations: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond, 40 * time.Millisecond, 50 * time.Millisecond},
+			p:         0.50,
+			expected:  30 * time.Millisecond,
+		},
+		{
+			name:      "p0 returns minimum",
+			durations: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond},
+			p:         0.0,
+			expected:  100 * time.Millisecond,
+		},
+		{
+			name:      "p100 returns maximum",
+			durations: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond},
+			p:         1.0,
+			expected:  300 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := percentile(tt.durations, tt.p)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestParseDuration verifies duration string parsing including day notation
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		hasError bool
+	}{
+		{
+			name:     "standard hour",
+			input:    "1h",
+			expected: time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "24 hours",
+			input:    "24h",
+			expected: 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "7 days",
+			input:    "7d",
+			expected: 7 * 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "1 day",
+			input:    "1d",
+			expected: 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "empty defaults to 1h",
+			input:    "",
+			expected: time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "whitespace defaults to 1h",
+			input:    "  ",
+			expected: time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "30 minutes",
+			input:    "30m",
+			expected: 30 * time.Minute,
+			hasError: false,
+		},
+		{
+			name:     "invalid format",
+			input:    "invalid",
+			expected: 0,
+			hasError: true,
+		},
+		{
+			name:     "invalid day format",
+			input:    "xd",
+			expected: 0,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseDuration(tt.input)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestStoreRecordCall verifies basic call recording functionality
+func TestStoreRecordCall(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	// Record successful call
+	store.RecordCall("gmail", "send_email", 500*time.Millisecond, nil)
+
+	// Record failed call
+	store.RecordCall("gmail", "send_email", 600*time.Millisecond, errors.New("timeout"))
+
+	calls := store.GetCallsInWindow("gmail", time.Hour)
+	require.Len(t, calls, 2)
+
+	assert.True(t, calls[0].Success)
+	assert.Equal(t, 500*time.Millisecond, calls[0].Duration)
+
+	assert.False(t, calls[1].Success)
+	assert.Equal(t, "timeout", calls[1].Error)
+}
+
+// TestStoreRecordCallTimeoutDetection verifies timeout errors are flagged
+func TestStoreRecordCallTimeoutDetection(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	// Record timeout error
+	store.RecordCall("slow-server", "heavy_op", 30*time.Second, errors.New("context deadline exceeded"))
+
+	calls := store.GetCallsInWindow("slow-server", time.Hour)
+	require.Len(t, calls, 1)
+
+	assert.False(t, calls[0].Success)
+	assert.True(t, calls[0].IsTimeout, "Timeout errors should be flagged")
+}
+
+// TestStoreGetCallsInWindowFiltering verifies server filtering works
+func TestStoreGetCallsInWindowFiltering(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	store.RecordCall("gmail", "send", 100*time.Millisecond, nil)
+	store.RecordCall("asana", "create_task", 200*time.Millisecond, nil)
+	store.RecordCall("gmail", "read", 150*time.Millisecond, nil)
+
+	// Filter by gmail
+	gmailCalls := store.GetCallsInWindow("gmail", time.Hour)
+	assert.Len(t, gmailCalls, 2)
+
+	// Filter by asana
+	asanaCalls := store.GetCallsInWindow("asana", time.Hour)
+	assert.Len(t, asanaCalls, 1)
+
+	// Get all calls (empty filter)
+	allCalls := store.GetCallsInWindow("", time.Hour)
+	assert.Len(t, allCalls, 3)
+}
+
+// TestStoreServerStats verifies server load tracking
+func TestStoreServerStats(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	// Record server load
+	store.RecordServerLoad("gmail", 150) // 150ms cold start
+
+	stats := store.GetServerStats("gmail")
+	require.NotNil(t, stats)
+	assert.Equal(t, "gmail", stats.Name)
+	assert.Equal(t, int64(150), stats.ColdStartMs)
+	assert.True(t, stats.IsConnected)
+
+	// Non-existent server
+	nilStats := store.GetServerStats("nonexistent")
+	assert.Nil(t, nilStats)
+}
+
+// TestStoreServerDisconnect verifies disconnect tracking
+func TestStoreServerDisconnect(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	store.RecordServerLoad("gmail", 100)
+	assert.Contains(t, store.GetActiveServers(), "gmail")
+
+	store.RecordServerDisconnect("gmail")
+
+	stats := store.GetServerStats("gmail")
+	require.NotNil(t, stats)
+	assert.False(t, stats.IsConnected)
+	assert.NotContains(t, store.GetActiveServers(), "gmail")
+}
+
+// TestStoreLifecycle verifies Start/Stop behavior
+func TestStoreLifecycle(t *testing.T) {
+	store := NewStore(100*time.Millisecond, "") // Short retention for testing
+
+	// Record some calls
+	store.RecordCall("server1", "tool1", 50*time.Millisecond, nil)
+	store.RecordCall("server1", "tool2", 100*time.Millisecond, errors.New("failed"))
+
+	calls := store.GetCallsInWindow("", time.Hour)
+	assert.Len(t, calls, 2)
+
+	// Stop should work without panic
+	store.Stop()
+}
+
+// TestStoreConcurrency verifies thread safety under concurrent access
+func TestStoreConcurrency(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 100
+
+	// Concurrent writes
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			store.RecordCall("server", fmt.Sprintf("tool_%d", n), time.Duration(n)*time.Millisecond, nil)
+		}(i)
+	}
+
+	// Concurrent reads while writes are happening
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = store.GetCallsInWindow("", time.Hour)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all writes completed
+	calls := store.GetCallsInWindow("", time.Hour)
+	assert.Len(t, calls, numGoroutines)
+}
+
+// TestGetMetrics verifies aggregated metrics computation
+func TestGetMetrics(t *testing.T) {
+	store := NewStore(time.Hour, "")
+	defer store.Stop()
+
+	// Add mixed results
+	for i := 0; i < 8; i++ {
+		store.RecordCall("server1", "tool", 100*time.Millisecond, nil)
+	}
+	store.RecordCall("server1", "tool", 100*time.Millisecond, errors.New("error1"))
+	store.RecordCall("server1", "tool", 100*time.Millisecond, errors.New("error2"))
+
+	store.RecordServerLoad("server1", 200)
+
+	metrics := store.GetMetrics("", time.Hour)
+
+	// Check summary
+	summary, ok := metrics["summary"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 10, summary["total_calls"])
+	assert.Equal(t, "80.0%", summary["success_rate"]) // 8/10 = 80%
+	assert.Equal(t, 1, summary["active_servers"])
+
+	// Check recent errors
+	recentErrors, ok := metrics["recent_errors"].([]map[string]interface{})
+	require.True(t, ok)
+	assert.Len(t, recentErrors, 2) // 2 errors recorded
+}
+
+// TestFormatDuration verifies human-readable duration formatting
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		expected string
+	}{
+		{100 * time.Millisecond, "100ms"},
+		{999 * time.Millisecond, "999ms"},
+		{1 * time.Second, "1.0s"},
+		{1500 * time.Millisecond, "1.5s"},
+		{60 * time.Second, "60.0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatDuration(tt.duration)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestIsTimeoutError verifies timeout error detection
+func TestIsTimeoutError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"context deadline exceeded", errors.New("context deadline exceeded"), true},
+		{"timeout", errors.New("operation timeout"), true},
+		{"timed out", errors.New("connection timed out"), true},
+		{"regular error", errors.New("connection refused"), false},
+		{"uppercase TIMEOUT", errors.New("TIMEOUT"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTimeoutError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/voicetreelab/lazy-mcp/internal/config"
 	"github.com/voicetreelab/lazy-mcp/internal/hierarchy"
+	"github.com/voicetreelab/lazy-mcp/internal/metrics"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -87,6 +88,32 @@ func StartStdioServer(cfg *config.Config) error {
 	// Create server registry for lazy-loaded MCP clients
 	registry := hierarchy.NewServerRegistry(cfg.McpServers)
 	defer registry.Close()
+
+	// Initialize metrics store if enabled (default: true)
+	var metricsStore *metrics.Store
+	metricsEnabled := true
+	if cfg.McpProxy.Options != nil && cfg.McpProxy.Options.MetricsEnabled.Present() {
+		metricsEnabled = cfg.McpProxy.Options.MetricsEnabled.OrElse(true)
+	}
+	if metricsEnabled {
+		retention := 8 * time.Hour // default
+		if cfg.McpProxy.Options != nil && cfg.McpProxy.Options.MetricsRetention != "" {
+			if parsed, err := metrics.ParseDuration(cfg.McpProxy.Options.MetricsRetention); err == nil {
+				retention = parsed
+			}
+		}
+		persistPath := ""
+		if cfg.McpProxy.Options != nil {
+			persistPath = cfg.McpProxy.Options.MetricsFile
+		}
+		metricsStore = metrics.InitGlobalStore(retention, persistPath)
+		// Ensure metrics goroutine is stopped on shutdown
+		defer metricsStore.Stop()
+		log.Printf("Metrics store initialized (retention=%s, persist=%v)", retention, persistPath != "")
+	}
+
+	// Set metrics store on registry for instrumentation
+	registry.SetMetricsStore(metricsStore)
 
 	// Create ONE MCP server with 2 meta-tools
 	serverOpts := []server.ServerOption{
@@ -197,6 +224,91 @@ func StartStdioServer(cfg *config.Config) error {
 
 		return h.HandleExecuteTool(ctx, registry, toolPath, arguments)
 	})
+
+	// Register proxy_doctor tool (observability)
+	if metricsStore != nil {
+		proxyDoctorTool := mcp.Tool{
+			Name:        "proxy_doctor",
+			Description: "Run diagnostics on the MCP proxy. Checks server health, identifies slow tools, timeout patterns, and suggests fixes. Use when experiencing issues with MCP tools.",
+			InputSchema: mcp.ToolInputSchema{
+				Type:       "object",
+				Properties: map[string]interface{}{},
+			},
+		}
+
+		// Get expected server names from config
+		expectedServers := make([]string, 0, len(cfg.McpServers))
+		for name := range cfg.McpServers {
+			expectedServers = append(expectedServers, name)
+		}
+
+		mcpServer.AddTool(proxyDoctorTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			result := metrics.RunDoctor(metricsStore, expectedServers)
+
+			jsonBytes, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.NewTextContent(string(jsonBytes)),
+				},
+			}, nil
+		})
+
+		// Register get_proxy_metrics tool
+		getProxyMetricsTool := mcp.Tool{
+			Name:        "get_proxy_metrics",
+			Description: "Get detailed performance metrics for the MCP proxy. Use to diagnose slow tools, timeouts, or errors. Returns latency percentiles (p50/p95/p99), error rates, and recent errors.",
+			InputSchema: mcp.ToolInputSchema{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"server": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by server name (optional). Omit to get metrics for all servers.",
+					},
+					"since": map[string]interface{}{
+						"type":        "string",
+						"description": "Time window: '1h', '24h', '7d' (default: '1h')",
+					},
+				},
+			},
+		}
+
+		mcpServer.AddTool(getProxyMetricsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			serverFilter := ""
+			since := time.Hour // default
+
+			if request.Params.Arguments != nil {
+				if argsMap, ok := request.Params.Arguments.(map[string]interface{}); ok {
+					if serverVal, ok := argsMap["server"].(string); ok {
+						serverFilter = serverVal
+					}
+					if sinceVal, ok := argsMap["since"].(string); ok {
+						if parsed, err := metrics.ParseDuration(sinceVal); err == nil {
+							since = parsed
+						}
+					}
+				}
+			}
+
+			result := metricsStore.GetMetrics(serverFilter, since)
+
+			jsonBytes, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.NewTextContent(string(jsonBytes)),
+				},
+			}, nil
+		})
+
+		log.Printf("Registered observability tools: proxy_doctor, get_proxy_metrics")
+	}
 
 	// Serve via stdio
 	log.Printf("Starting hierarchical MCP proxy (stdio server)")


### PR DESCRIPTION
## Summary

This PR combines **PR #11** (auto-reconnect) and **PR #12** (observability) into a single, coherent PR to simplify the review process.

**Note to reviewer:** We've consolidated both features because they share common infrastructure (metrics integration with retry logic). This should make the review easier to follow as a single coherent change.

### Feature 1: Auto-reconnect on Backend Server Crash

When a backend MCP server dies (e.g., `pkill -f playwright`), the proxy now automatically recovers:

- `isTransportError()` helper detects transport-level errors (broken pipe, connection reset, etc.)
- `RemoveClient()` method for cache invalidation
- Retry logic in `HandleExecuteTool()`: on transport error, removes stale client and retries once

**Important:** Timeout errors (`context deadline exceeded`) do NOT trigger retry to avoid duplicate operations.

### Feature 2: Observability Tools

Self-diagnosing observability via two new MCP tools:
- `proxy_doctor` - Health checks with actionable suggestions
- `get_proxy_metrics` - Latency percentiles (p50/p95/p99), error rates

Zero external dependencies, in-memory metrics with optional persistence.

## Review Comment Responses

See comments on PR #11 and PR #12 for detailed responses to the AI-generated review feedback:
- PR #11: https://github.com/voicetreelab/lazy-mcp/pull/11
- PR #12: https://github.com/voicetreelab/lazy-mcp/pull/12

Key fixes incorporated:
- ✅ Removed timeout errors from transport error classification (prevents duplicate ops)
- ✅ Added `UnmarshalJSON` for proper persistence loading
- ✅ Added `defer metricsStore.Stop()` to prevent goroutine leak
- ✅ Fixed threshold display in doctor.go

## Test Results

```bash
go test ./internal/hierarchy/... -v
# All 22 tests pass (mutex, transport errors, retry logic)
```

## Files Changed

| File | Description |
|------|-------------|
| `internal/hierarchy/hierarchy.go` | Retry logic + metrics integration |
| `internal/hierarchy/transport_error_test.go` | Unit tests (17 test cases) |
| `internal/metrics/store.go` | In-memory metrics store |
| `internal/metrics/doctor.go` | Health check logic |
| `internal/config/config.go` | Metrics config options |
| `internal/server/server.go` | Register observability tools |
| `docs/OBSERVABILITY.md` | Documentation |

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)